### PR TITLE
Extract and store DICOM JSON.

### DIFF
--- a/docs/setup/setup.md
+++ b/docs/setup/setup.md
@@ -136,7 +136,34 @@ Locate the storage section of the configuration in `appsettings.json`:
   }
 }
 ```
+### DICOM JSON Model
 
+By default, Informatics Gateway stores all received and retrieved DICOM instances into JSON in additional to storing
+the original in DICOM part-10 format.  The JSON stored is as specified by the [DICOM JSON model](https://dicom.nema.org/dicom/2013/output/chtml/part18/sect_F.2.html)
+without the following VR types:
+
+- OB
+- OD
+- OF
+- OL
+- OV
+- OW
+- UN
+
+This behavior may be changed in the configuration file:
+```json
+{
+
+  "InformaticsGateway": {
+    "dicom": {
+      "writeDicomJson": "None|IgnoreOthers|Complete"
+    },   
+    ...
+  }
+}
+```
+
+Refer to the [DicomJsonOptions](xref:Monai.Deploy.InformaticsGateway.Configuration.DicomJsonOptions) for complete description.
 
 ## Summary
 

--- a/src/Api/MessageBroker/Message.cs
+++ b/src/Api/MessageBroker/Message.cs
@@ -63,20 +63,6 @@ namespace Monai.Deploy.InformaticsGateway.Api.MessageBroker
 
         public Message(byte[] body,
                        string bodyDescription,
-                       string contentType,
-                       string correlationId)
-            : this(body,
-                   bodyDescription,
-                   Guid.NewGuid().ToString(),
-                   Message.InformaticsGatewayApplicationId,
-                   contentType,
-                   correlationId,
-                   DateTime.UtcNow)
-        {
-        }
-
-        public Message(byte[] body,
-                       string bodyDescription,
                        string messageId,
                        string applicationId,
                        string contentType,

--- a/src/Api/MessageBroker/WorkflowRequestMessage.cs
+++ b/src/Api/MessageBroker/WorkflowRequestMessage.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿// Copyright 2022 MONAI Consortium
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Monai.Deploy.InformaticsGateway.Api.Storage;
+using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 
 namespace Monai.Deploy.InformaticsGateway.Api.MessageBroker
@@ -6,28 +19,39 @@ namespace Monai.Deploy.InformaticsGateway.Api.MessageBroker
     public class WorkflowRequestMessage
     {
         /// <summary>
-        /// Gets or sets the name of bucket where the payload is stored.
-        /// </summary>
-        public string Bucket { get; set; }
-
-        /// <summary>
         /// Gets or sets the ID of the payload which is also used as the root path of the payload.
         /// </summary>
+        [JsonProperty(PropertyName = "payload_id")]
         public Guid PayloadId { get; set; }
 
         /// <summary>
         /// Gets or sets the associated workflows to be launched.
         /// </summary>
+        [JsonProperty(PropertyName = "workflows")]
         public IEnumerable<string> Workflows { get; set; }
 
         /// <summary>
         /// Gets or sets number of files in the payload.
         /// </summary>
+        [JsonProperty(PropertyName = "file_count")]
         public int FileCount { get; set; }
 
         /// <summary>
         /// For DIMSE, the correlation ID is the UUID associated with the first DICOM association received. For an ACR inference request, the correlation ID is the Transaction ID in the original request.
         /// </summary>
+        [JsonProperty(PropertyName = "correlation_id")]
         public string CorrelationId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the time the data was received.
+        /// </summary>
+        [JsonProperty(PropertyName = "timestamp")]
+        public DateTime Timestamp { get; set; }
+
+        /// <summary>
+        /// Gets or sets a list of files and metadata files in this request.
+        /// </summary>
+        [JsonProperty(PropertyName = "payload")]
+        public List<BlockStorageInfo> Payload { get; } = new List<BlockStorageInfo>();
     }
 }

--- a/src/Api/Storage/BlockStorageInfo.cs
+++ b/src/Api/Storage/BlockStorageInfo.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2022 MONAI Consortium
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Newtonsoft.Json;
+
+namespace Monai.Deploy.InformaticsGateway.Api.Storage
+{
+    public class BlockStorageInfo
+    {
+        /// <summary>
+        /// Gets or sets the name of bucket where the file is stored.
+        /// </summary>
+        [JsonProperty(PropertyName = "bucket")]
+        public string Bucket { get; set; }
+
+        /// <summary>
+        /// Gets or sets the root path to the file.
+        /// </summary>
+        [JsonProperty(PropertyName = "path")]
+        public string Path { get; set; }
+
+        /// <summary>
+        /// Gets or sets the root path to the metadata file.
+        /// </summary>
+        [JsonProperty(PropertyName = "metadata")]
+        public string Metadata { get; set; }
+    }
+}

--- a/src/Api/Storage/FhirFileStorageInfo.cs
+++ b/src/Api/Storage/FhirFileStorageInfo.cs
@@ -20,7 +20,9 @@ namespace Monai.Deploy.InformaticsGateway.Api.Storage
     /// </summary>
     public sealed record FhirFileStorageInfo : FileStorageInfo
     {
-        const string DirectoryPath = "ehr";
+        public static readonly string JsonFilExtension = ".json";
+        public static readonly string XmlFilExtension = ".xml";
+        private static readonly string DirectoryPath = "ehr";
 
         public string ResourceType { get; set; }
 
@@ -31,7 +33,7 @@ namespace Monai.Deploy.InformaticsGateway.Api.Storage
                                     string messageId,
                                     FhirStorageFormat fhirFileFormat,
                                     string source)
-            : base(correlationId, storageRootPath, messageId, fhirFileFormat == FhirStorageFormat.Json ? ".json" : ".xml", source, new FileSystem()) { }
+            : base(correlationId, storageRootPath, messageId, fhirFileFormat == FhirStorageFormat.Json ? JsonFilExtension : XmlFilExtension, source, new FileSystem()) { }
 
         public FhirFileStorageInfo(string correlationId,
                                     string storageRootPath,
@@ -39,7 +41,7 @@ namespace Monai.Deploy.InformaticsGateway.Api.Storage
                                     FhirStorageFormat fhirFileFormat,
                                     string source,
                                     IFileSystem fileSystem)
-            : base(correlationId, storageRootPath, messageId, fhirFileFormat == FhirStorageFormat.Json ? ".json" : ".xml", source, fileSystem)
+            : base(correlationId, storageRootPath, messageId, fhirFileFormat == FhirStorageFormat.Json ? JsonFilExtension : XmlFilExtension, source, fileSystem)
         {
         }
 

--- a/src/Api/Storage/FileStorageInfo.cs
+++ b/src/Api/Storage/FileStorageInfo.cs
@@ -11,6 +11,7 @@
 
 using Ardalis.GuardClauses;
 using System;
+using System.Collections.Generic;
 using System.IO.Abstractions;
 
 namespace Monai.Deploy.InformaticsGateway.Api.Storage
@@ -71,10 +72,10 @@ namespace Monai.Deploy.InformaticsGateway.Api.Storage
         {
             get
             {
-                var path = FilePath.Substring(StorageRootPath.Length);
+                var path = FilePath[StorageRootPath.Length..];
                 if (FileSystem.Path.IsPathRooted(path))
                 {
-                    return path.Substring(1);
+                    return path[1..];
                 }
                 return path;
             }
@@ -117,6 +118,17 @@ namespace Monai.Deploy.InformaticsGateway.Api.Storage
         /// Gets or sets the content type of the file.
         /// </summary>
         public string ContentType { get; set; }
+
+        /// <summary>
+        /// Gets the file and any associated meta files.
+        /// </summary>
+        public virtual IEnumerable<string> FilePaths
+        {
+            get
+            {
+                yield return _filePath;
+            }
+        }
 
         public FileStorageInfo() { }
 
@@ -184,6 +196,15 @@ namespace Monai.Deploy.InformaticsGateway.Api.Storage
             }
 
             return filePath;
+        }
+
+        public virtual BlockStorageInfo ToBlockStorageInfo(string bucket)
+        {
+            return new BlockStorageInfo
+            {
+                Bucket = bucket,
+                Path = UploadPath,
+            };
         }
     }
 }

--- a/src/Api/Storage/Payload.cs
+++ b/src/Api/Storage/Payload.cs
@@ -48,6 +48,8 @@ namespace Monai.Deploy.InformaticsGateway.Api.Storage
 
         public string Key { get; init; }
 
+        public DateTime DateTimeCreated { get; private set; }
+
         public int RetryCount { get; set; }
 
         public bool HasTimedOut { get => ElapsedTime().TotalSeconds >= Timeout; }
@@ -67,6 +69,7 @@ namespace Monai.Deploy.InformaticsGateway.Api.Storage
         }
 
         public string CorrelationId { get; init; }
+        public IList<BlockStorageInfo> UploadedFiles { get; set; }
 
         public Payload(string key, string correlationId, uint timeout)
         {
@@ -80,6 +83,7 @@ namespace Monai.Deploy.InformaticsGateway.Api.Storage
             RetryCount = 0;
             State = PayloadState.Created;
             Files = new List<FileStorageInfo>();
+            UploadedFiles = new List<BlockStorageInfo>();
         }
 
         public void Add(FileStorageInfo value)
@@ -89,6 +93,11 @@ namespace Monai.Deploy.InformaticsGateway.Api.Storage
             Files.Add(value);
             _lastReceived.Reset();
             _lastReceived.Start();
+
+            if(Files.Count == 1)
+            {
+                DateTimeCreated = value.Received;
+            }
         }
 
         public TimeSpan ElapsedTime()

--- a/src/Configuration/DicomConfiguration.cs
+++ b/src/Configuration/DicomConfiguration.cs
@@ -46,5 +46,11 @@ namespace Monai.Deploy.InformaticsGateway.Configuration
         /// </summary>
         [JsonProperty(PropertyName = "scu")]
         public ScuConfiguration Scu { get; set; } = new ScuConfiguration();
+
+        /// <summary>
+        /// Gets or sets whether to write DICOM JSON file for each instance received.
+        /// </summary>
+        [JsonProperty(PropertyName = "writeDicomJson")]
+        public DicomJsonOptions WriteDicomJson { get; set; } = DicomJsonOptions.IgnoreOthers;
     }
 }

--- a/src/Configuration/DicomJsonOptions.cs
+++ b/src/Configuration/DicomJsonOptions.cs
@@ -11,7 +11,7 @@
 
 /*
  * Apache License, Version 2.0
- * Copyright 2019-2020 NVIDIA Corporation
+ * Copyright 2019-2021 NVIDIA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,22 +26,23 @@
  * limitations under the License.
  */
 
-using FellowOakDicom;
-using Monai.Deploy.InformaticsGateway.Configuration;
-using System.Threading.Tasks;
-
-namespace Monai.Deploy.InformaticsGateway.Common
+namespace Monai.Deploy.InformaticsGateway.Configuration
 {
-    public interface IDicomToolkit
+    public enum DicomJsonOptions
     {
-        DicomFile Open(string path);
+        /// <summary>
+        /// Do not write DICOM to JSON
+        /// </summary>
+        None,
 
-        bool HasValidHeader(string path);
+        /// <summary>
+        /// Writes DICOM to JSON exception VR types of OB, OD, OF, OL, OV, OW, and UN.
+        /// </summary>
+        IgnoreOthers,
 
-        bool TryGetString(DicomFile file, DicomTag dicomTag, out string value);
-
-        Task Save(DicomFile file, string filename, string metadataFilename, DicomJsonOptions dicomJsonOptions);
-
-        DicomFile Load(byte[] fileContent);
+        /// <summary>
+        /// Writes DICOM to JSON
+        /// </summary>
+        Complete
     }
 }

--- a/src/Database/Migrations/20220203222116_R1_Initialize.Designer.cs
+++ b/src/Database/Migrations/20220203222116_R1_Initialize.Designer.cs
@@ -11,7 +11,7 @@ using Monai.Deploy.InformaticsGateway.Database;
 namespace Monai.Deploy.InformaticsGateway.Database.Migrations
 {
     [DbContext(typeof(InformaticsGatewayContext))]
-    [Migration("20220202191245_R1_Initialize")]
+    [Migration("20220203222116_R1_Initialize")]
     partial class R1_Initialize
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -135,6 +135,9 @@ namespace Monai.Deploy.InformaticsGateway.Database.Migrations
                     b.Property<string>("CorrelationId")
                         .HasColumnType("TEXT");
 
+                    b.Property<DateTime>("DateTimeCreated")
+                        .HasColumnType("TEXT");
+
                     b.Property<string>("Files")
                         .HasColumnType("TEXT");
 
@@ -150,6 +153,9 @@ namespace Monai.Deploy.InformaticsGateway.Database.Migrations
 
                     b.Property<uint>("Timeout")
                         .HasColumnType("INTEGER");
+
+                    b.Property<string>("UploadedFiles")
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 

--- a/src/Database/Migrations/20220203222116_R1_Initialize.cs
+++ b/src/Database/Migrations/20220203222116_R1_Initialize.cs
@@ -66,10 +66,12 @@ namespace Monai.Deploy.InformaticsGateway.Database.Migrations
                     Id = table.Column<Guid>(type: "TEXT", nullable: false),
                     Timeout = table.Column<uint>(type: "INTEGER", nullable: false),
                     Key = table.Column<string>(type: "TEXT", nullable: false),
+                    DateTimeCreated = table.Column<DateTime>(type: "TEXT", nullable: false),
                     RetryCount = table.Column<int>(type: "INTEGER", nullable: false),
                     State = table.Column<int>(type: "INTEGER", nullable: false),
                     Files = table.Column<string>(type: "TEXT", nullable: true),
-                    CorrelationId = table.Column<string>(type: "TEXT", nullable: true)
+                    CorrelationId = table.Column<string>(type: "TEXT", nullable: true),
+                    UploadedFiles = table.Column<string>(type: "TEXT", nullable: true)
                 },
                 constraints: table =>
                 {

--- a/src/Database/Migrations/InformaticsGatewayContextModelSnapshot.cs
+++ b/src/Database/Migrations/InformaticsGatewayContextModelSnapshot.cs
@@ -133,6 +133,9 @@ namespace Monai.Deploy.InformaticsGateway.Database.Migrations
                     b.Property<string>("CorrelationId")
                         .HasColumnType("TEXT");
 
+                    b.Property<DateTime>("DateTimeCreated")
+                        .HasColumnType("TEXT");
+
                     b.Property<string>("Files")
                         .HasColumnType("TEXT");
 
@@ -148,6 +151,9 @@ namespace Monai.Deploy.InformaticsGateway.Database.Migrations
 
                     b.Property<uint>("Timeout")
                         .HasColumnType("INTEGER");
+
+                    b.Property<string>("UploadedFiles")
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 

--- a/src/Database/PayloadConfiguration.cs
+++ b/src/Database/PayloadConfiguration.cs
@@ -24,7 +24,12 @@ namespace Monai.Deploy.InformaticsGateway.Database
     {
         public void Configure(EntityTypeBuilder<Payload> builder)
         {
-            var valueComparer = new ValueComparer<IList<FileStorageInfo>>(
+            var fileStorageInfoComparer = new ValueComparer<IList<FileStorageInfo>>(
+                (c1, c2) => c1.SequenceEqual(c2),
+                c => c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
+                c => c.ToList());
+
+            var blockStorageInfoComparer = new ValueComparer<IList<BlockStorageInfo>>(
                 (c1, c2) => c1.SequenceEqual(c2),
                 c => c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
                 c => c.ToList());
@@ -41,7 +46,12 @@ namespace Monai.Deploy.InformaticsGateway.Database
                 .HasConversion(
                         v => JsonConvert.SerializeObject(v, jsonSerializerSettings),
                         v => JsonConvert.DeserializeObject<IList<FileStorageInfo>>(v, jsonSerializerSettings))
-                .Metadata.SetValueComparer(valueComparer);
+                .Metadata.SetValueComparer(fileStorageInfoComparer);
+            builder.Property(j => j.UploadedFiles)
+                .HasConversion(
+                        v => JsonConvert.SerializeObject(v, jsonSerializerSettings),
+                        v => JsonConvert.DeserializeObject<IList<BlockStorageInfo>>(v, jsonSerializerSettings))
+                .Metadata.SetValueComparer(blockStorageInfoComparer);
         }
     }
 }

--- a/src/InformaticsGateway/Common/DicomToJsonConverter.cs
+++ b/src/InformaticsGateway/Common/DicomToJsonConverter.cs
@@ -1,0 +1,1015 @@
+﻿// Copyright (c) 2012-2021 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+// Source https://github.com/fo-dicom/fo-dicom/blob/development/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
+// Issue created to support the option of not writing O* and UN VR value types. https://github.com/fo-dicom/fo-dicom/issues/1321
+
+using FellowOakDicom;
+using FellowOakDicom.IO.Buffer;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+
+namespace Monai.Deploy.InformaticsGateway.Common
+{
+    /// <summary>
+    /// Converts a DicomDataset object to and from JSON using the NewtonSoft Json.NET library
+    /// </summary>
+    internal class DicomJsonConverter : JsonConverter<DicomDataset>
+    {
+        private readonly bool _writeTagsAsKeywords;
+        private readonly bool _autoValidate;
+        private readonly bool _writeOtherValueTypes;
+        private static readonly Encoding[] _jsonTextEncodings = { Encoding.UTF8 };
+        private static readonly char _personNameComponentGroupDelimiter = '=';
+        private static readonly string[] _personNameComponentGroupNames = { "Alphabetic", "Ideographic", "Phonetic" };
+
+        private delegate T GetValue<out T>(Utf8JsonReader reader);
+
+        private delegate bool TryParse<T>(string value, out T parsed);
+
+        private delegate void WriteValue<in T>(Utf8JsonWriter writer, T value);
+
+        /// <summary>
+        /// Initialize the JsonDicomConverter.
+        /// </summary>
+        /// <param name="writeTagsAsKeywords">Whether to write the json keys as DICOM keywords instead of tags. This makes the json non-compliant to DICOM JSON.</param>
+        /// <param name="autoValidate">Whether the content of DicomItems shall be validated as soon as they are added to the DicomDataset. </param>
+        public DicomJsonConverter(bool writeTagsAsKeywords = false, bool autoValidate = true, bool writeOtherValueTypes = true)
+        {
+            _writeTagsAsKeywords = writeTagsAsKeywords;
+            _autoValidate = autoValidate;
+            _writeOtherValueTypes = writeOtherValueTypes;
+        }
+
+        #region JsonConverter overrides
+
+        /// <summary>
+        /// Writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="T:System.Text.Json.Utf8JsonWriter"/> to write to.</param>
+        /// <param name="value">The value.</param>
+        public override void Write(Utf8JsonWriter writer, DicomDataset value, JsonSerializerOptions options)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            writer.WriteStartObject();
+            foreach (var item in value)
+            {
+                if (((uint)item.Tag & 0xffff) == 0)
+                {
+                    // Group length (gggg,0000) attributes shall not be included in a DICOM JSON Model object.
+                    continue;
+                }
+
+                // Unknown or masked tags cannot be written as keywords
+                var unknown = item.Tag.DictionaryEntry == null
+                              || string.IsNullOrWhiteSpace(item.Tag.DictionaryEntry.Keyword)
+                              ||
+                              (item.Tag.DictionaryEntry.MaskTag != null &&
+                               item.Tag.DictionaryEntry.MaskTag.Mask != 0xffffffff);
+                if (_writeTagsAsKeywords && !unknown)
+                {
+                    writer.WritePropertyName(item.Tag.DictionaryEntry.Keyword);
+                }
+                else
+                {
+                    writer.WritePropertyName(item.Tag.Group.ToString("X4") + item.Tag.Element.ToString("X4"));
+                }
+
+                WriteJsonDicomItem(writer, item, options);
+            }
+            writer.WriteEndObject();
+        }
+
+        /// <summary>
+        /// Reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="T:System.Text.Json.Utf8JsonReader"/> to read from.</param>
+        /// <param name="typeToConvert">Type of the object.</param>
+        /// <param name="options">Options to apply while reading.</param>
+        /// <returns>
+        /// The object value.
+        /// </returns>
+        public override DicomDataset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var dataset = ReadJsonDataset(ref reader);
+            return dataset;
+        }
+
+        private DicomDataset ReadJsonDataset(ref Utf8JsonReader reader)
+        {
+            var dataset = _autoValidate
+                ? new DicomDataset()
+                : new DicomDataset().NotValidated();
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException($"Expected the start of an object but found '{reader.TokenType}'.");
+            }
+            reader.Read();
+
+            while (reader.TokenType != JsonTokenType.EndObject)
+            {
+                reader.Assume(JsonTokenType.PropertyName);
+                var tagstr = reader.GetString();
+                DicomTag tag = ParseTag(tagstr);
+                reader.Read(); // move to value
+                var item = ReadJsonDicomItem(tag, ref reader);
+                dataset.Add(item);
+            }
+
+            foreach (var item in dataset)
+            {
+                if (item.Tag.IsPrivate && ((item.Tag.Element & 0xff00) != 0))
+                {
+                    var privateCreatorTag = new DicomTag(item.Tag.Group, (ushort)(item.Tag.Element >> 8));
+
+                    if (dataset.Contains(privateCreatorTag))
+                    {
+                        item.Tag.PrivateCreator = new DicomPrivateCreator(dataset.GetSingleValue<string>(privateCreatorTag));
+                    }
+                }
+            }
+
+            return dataset;
+        }
+
+        /// <summary>
+        /// Determines whether this instance can convert the specified object type.
+        /// </summary>
+        /// <param name="objectType">Type of the object.</param>
+        /// <returns>
+        /// <c>true</c> if this instance can convert the specified object type; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool CanConvert(Type typeToConvert)
+        {
+            return typeof(DicomDataset).GetTypeInfo().IsAssignableFrom(typeToConvert.GetTypeInfo());
+        }
+
+        #endregion JsonConverter overrides
+
+        /// <summary>
+        /// Create an instance of a IBulkDataUriByteBuffer. Override this method to use a different IBulkDataUriByteBuffer implementation in applications.
+        /// </summary>
+        /// <param name="bulkDataUri">The URI of a bulk data element as defined in <see cref="!:http://dicom.nema.org/medical/dicom/current/output/chtml/part19/chapter_A.html#table_A.1.5-2">Table A.1.5-2 in PS3.19</see>.</param>
+        /// <returns>An instance of a Bulk URI Byte buffer.</returns>
+        protected virtual IBulkDataUriByteBuffer CreateBulkDataUriByteBuffer(string bulkDataUri) => new BulkDataUriByteBuffer(bulkDataUri);
+
+        #region Utilities
+
+        internal static DicomTag ParseTag(string tagstr)
+        {
+            if (Regex.IsMatch(tagstr, @"\A\b[0-9a-fA-F]+\b\Z"))
+            {
+                var group = Convert.ToUInt16(tagstr[..4], 16);
+                var element = Convert.ToUInt16(tagstr[4..], 16);
+                var tag = new DicomTag(group, element);
+                return tag;
+            }
+
+            return DicomDictionary.Default[tagstr];
+        }
+
+        private static DicomItem CreateDicomItem(DicomTag tag, string vr, object data)
+        {
+            DicomItem item = vr switch
+            {
+                "AE" => new DicomApplicationEntity(tag, (string[])data),
+                "AS" => new DicomAgeString(tag, (string[])data),
+                "AT" => new DicomAttributeTag(tag, ((string[])data).Select(ParseTag).ToArray()),
+                "CS" => new DicomCodeString(tag, (string[])data),
+                "DA" => new DicomDate(tag, (string[])data),
+                "DS" => data is IByteBuffer dataBufferDS
+                            ? new DicomDecimalString(tag, dataBufferDS)
+                            : new DicomDecimalString(tag, (decimal[])data),
+                "DT" => new DicomDateTime(tag, (string[])data),
+                "FD" => data is IByteBuffer dataBufferFD
+                            ? new DicomFloatingPointDouble(tag, dataBufferFD)
+                            : new DicomFloatingPointDouble(tag, (double[])data),
+                "FL" => data is IByteBuffer dataBufferFL
+                            ? new DicomFloatingPointSingle(tag, dataBufferFL)
+                            : new DicomFloatingPointSingle(tag, (float[])data),
+                "IS" => data is IByteBuffer dataBufferIS
+                            ? new DicomIntegerString(tag, dataBufferIS)
+                            : new DicomIntegerString(tag, (int[])data),
+                "LO" => new DicomLongString(tag, (string[])data),
+                "LT" => data is IByteBuffer dataBufferLT
+                            ? new DicomLongText(tag, _jsonTextEncodings, dataBufferLT)
+                            : new DicomLongText(tag, data.GetAsStringArray().GetSingleOrEmpty()),
+                "OB" => new DicomOtherByte(tag, (IByteBuffer)data),
+                "OD" => new DicomOtherDouble(tag, (IByteBuffer)data),
+                "OF" => new DicomOtherFloat(tag, (IByteBuffer)data),
+                "OL" => new DicomOtherLong(tag, (IByteBuffer)data),
+                "OW" => new DicomOtherWord(tag, (IByteBuffer)data),
+                "OV" => new DicomOtherVeryLong(tag, (IByteBuffer)data),
+                "PN" => new DicomPersonName(tag, (string[])data),
+                "SH" => new DicomShortString(tag, (string[])data),
+                "SL" => data is IByteBuffer dataBufferSL
+                            ? new DicomSignedLong(tag, dataBufferSL)
+                            : new DicomSignedLong(tag, (int[])data),
+                "SQ" => new DicomSequence(tag, ((DicomDataset[])data)),
+                "SS" => data is IByteBuffer dataBufferSS
+                            ? new DicomSignedShort(tag, dataBufferSS)
+                            : new DicomSignedShort(tag, (short[])data),
+                "ST" => data is IByteBuffer dataBufferST
+                            ? new DicomShortText(tag, _jsonTextEncodings, dataBufferST)
+                            : new DicomShortText(tag, data.GetAsStringArray().GetFirstOrEmpty()),
+                "SV" => data is IByteBuffer dataBufferSV
+                                ? new DicomSignedVeryLong(tag, dataBufferSV)
+                                : new DicomSignedVeryLong(tag, (long[])data),
+                "TM" => new DicomTime(tag, (string[])data),
+                "UC" => data is IByteBuffer dataBufferUC
+                            ? new DicomUnlimitedCharacters(tag, _jsonTextEncodings, dataBufferUC)
+                            : new DicomUnlimitedCharacters(tag, data.GetAsStringArray().SingleOrDefault()),
+                "UI" => new DicomUniqueIdentifier(tag, (string[])data),
+                "UL" => data is IByteBuffer dataBufferUL
+                            ? new DicomUnsignedLong(tag, dataBufferUL)
+                            : new DicomUnsignedLong(tag, (uint[])data),
+                "UN" => new DicomUnknown(tag, (IByteBuffer)data),
+                "UR" => new DicomUniversalResource(tag, data.GetAsStringArray().GetSingleOrEmpty()),
+                "US" => data is IByteBuffer dataBufferUS
+                            ? new DicomUnsignedShort(tag, dataBufferUS)
+                            : new DicomUnsignedShort(tag, (ushort[])data),
+                "UT" => data is IByteBuffer dataBufferUT
+                            ? new DicomUnlimitedText(tag, _jsonTextEncodings, dataBufferUT)
+                            : new DicomUnlimitedText(tag, data.GetAsStringArray().GetSingleOrEmpty()),
+                "UV" => data is IByteBuffer dataBufferUV
+                            ? new DicomUnsignedVeryLong(tag, dataBufferUV)
+                            : new DicomUnsignedVeryLong(tag, (ulong[])data),
+                _ => throw new NotSupportedException("Unsupported value representation"),
+            };
+            return item;
+        }
+
+        #endregion Utilities
+
+        #region WriteJson helpers
+
+        private void WriteJsonDicomItem(Utf8JsonWriter writer, DicomItem item, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("vr", item.ValueRepresentation.Code);
+
+            switch (item.ValueRepresentation.Code)
+            {
+                case "PN":
+                    WriteJsonPersonName(writer, (DicomPersonName)item);
+                    break;
+
+                case "SQ":
+                    WriteJsonSequence(writer, (DicomSequence)item, options);
+                    break;
+
+                case "OB":
+                case "OD":
+                case "OF":
+                case "OL":
+                case "OV":
+                case "OW":
+                case "UN":
+                    if (_writeOtherValueTypes)
+                    {
+                        WriteJsonOther(writer, (DicomElement)item);
+                    }
+                    break;
+
+                case "FL":
+                    WriteJsonElement<float>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
+                    break;
+
+                case "FD":
+                    WriteJsonElement<double>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
+                    break;
+
+                case "IS":
+                case "SL":
+                    WriteJsonElement<int>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
+                    break;
+
+                case "SS":
+                    WriteJsonElement<short>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
+                    break;
+
+                case "SV":
+                    WriteJsonElement<long>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
+                    break;
+
+                case "UL":
+                    WriteJsonElement<uint>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
+                    break;
+
+                case "US":
+                    WriteJsonElement<ushort>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
+                    break;
+
+                case "UV":
+                    WriteJsonElement<ulong>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
+                    break;
+
+                case "DS":
+                    WriteJsonDecimalString(writer, (DicomElement)item);
+                    break;
+
+                case "AT":
+                    WriteJsonAttributeTag(writer, (DicomElement)item);
+                    break;
+
+                default:
+                    WriteJsonElement<string>(writer, (DicomElement)item, (w, v) => writer.WriteStringValue(v));
+                    break;
+            }
+            writer.WriteEndObject();
+        }
+
+        private static void WriteJsonDecimalString(Utf8JsonWriter writer, DicomElement elem)
+        {
+            if (elem.Count != 0)
+            {
+                writer.WritePropertyName("Value");
+                writer.WriteStartArray();
+                foreach (var val in elem.Get<string[]>())
+                {
+                    if (string.IsNullOrEmpty(val))
+                    {
+                        writer.WriteNullValue();
+                    }
+                    else
+                    {
+                        var fix = FixDecimalString(val);
+                        if (TryParseULong(fix, out ulong xulong))
+                        {
+                            writer.WriteNumberValue(xulong);
+                        }
+                        else if (TryParseLong(fix, out long xlong))
+                        {
+                            writer.WriteNumberValue(xlong);
+                        }
+                        else if (TryParseDecimal(fix, out decimal xdecimal))
+                        {
+                            writer.WriteNumberValue(xdecimal);
+                        }
+                        else if (TryParseDouble(fix, out double xdouble))
+                        {
+                            writer.WriteNumberValue(xdouble);
+                        }
+                        else
+                        {
+                            throw new FormatException($"Cannot write dicom number {val} to json");
+                        }
+                    }
+                }
+                writer.WriteEndArray();
+            }
+        }
+
+        private static bool IsValidJsonNumber(string val)
+        {
+            try
+            {
+                DicomValidation.ValidateDS(val);
+                return true;
+            }
+            catch (DicomValidationException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Fix-up a Dicom DS number for use with json.
+        /// Rationale: There is a requirement that DS numbers shall be written as json numbers in part 18.F json, but the
+        /// requirements on DS allows values that are not json numbers. This method "fixes" them to conform to json numbers.
+        /// </summary>
+        /// <param name="val">A valid DS value</param>
+        /// <returns>A json number equivalent to the supplied DS value</returns>
+        private static string FixDecimalString(string val)
+        {
+            // trim invalid padded character
+            val = val.Trim().TrimEnd('\0');
+
+            if (IsValidJsonNumber(val))
+            {
+                return val;
+            }
+
+            if (string.IsNullOrWhiteSpace(val)) { return null; }
+
+            val = val.Trim();
+
+            var negative = false;
+            // Strip leading superfluous plus signs
+            if (val[0] == '+')
+            {
+                val = val[1..];
+            }
+            else if (val[0] == '-')
+            {
+                // Temporarily remove negation sign for zero-stripping later
+                negative = true;
+                val = val[1..];
+            }
+
+            // Strip leading superfluous zeros
+            if (val.Length > 1 && val[0] == '0' && val[1] != '.')
+            {
+                int i = 0;
+                while (i < val.Length - 1 && val[i] == '0' && val[i + 1] != '.')
+                {
+                    i++;
+                }
+
+                val = val[i..];
+            }
+
+            // Re-add negation sign
+            if (negative) { val = "-" + val; }
+
+            if (IsValidJsonNumber(val))
+            {
+                return val;
+            }
+
+            throw new ArgumentException("Failed converting DS value to json");
+        }
+
+        private static void WriteJsonElement<T>(Utf8JsonWriter writer, DicomElement elem, WriteValue<T> writeValue)
+        {
+            if (elem.Count != 0)
+            {
+                writer.WritePropertyName("Value");
+                writer.WriteStartArray();
+                foreach (var val in elem.Get<T[]>())
+                {
+                    if (val == null || (typeof(T) == typeof(string) && val.Equals("")))
+                    {
+                        writer.WriteNullValue();
+                    }
+                    else if (val is float f && float.IsNaN(f))
+                    {
+                        writer.WriteStringValue("NaN");
+                    }
+                    else
+                    {
+                        writeValue(writer, val);
+                    }
+                }
+                writer.WriteEndArray();
+            }
+        }
+
+        private static void WriteJsonAttributeTag(Utf8JsonWriter writer, DicomElement elem)
+        {
+            if (elem.Count != 0)
+            {
+                writer.WritePropertyName("Value");
+                writer.WriteStartArray();
+                foreach (var val in elem.Get<DicomTag[]>())
+                {
+                    if (val == null) { writer.WriteNullValue(); }
+                    else { writer.WriteStringValue(((uint)val).ToString("X8")); }
+                }
+                writer.WriteEndArray();
+            }
+        }
+
+        private static void WriteJsonOther(Utf8JsonWriter writer, DicomElement elem)
+        {
+            if (elem.Buffer is IBulkDataUriByteBuffer buffer)
+            {
+                writer.WritePropertyName("BulkDataURI");
+                writer.WriteStringValue(buffer.BulkDataUri);
+            }
+            else if (elem.Count != 0)
+            {
+                writer.WritePropertyName("InlineBinary");
+                writer.WriteStartArray();
+                writer.WriteBase64StringValue(elem.Buffer.Data);
+                writer.WriteEndArray();
+            }
+        }
+
+        private void WriteJsonSequence(Utf8JsonWriter writer, DicomSequence seq, JsonSerializerOptions options)
+        {
+            if (seq.Items.Count != 0)
+            {
+                writer.WritePropertyName("Value");
+                writer.WriteStartArray();
+
+                foreach (var child in seq.Items)
+                {
+                    Write(writer, child, options);
+                }
+
+                writer.WriteEndArray();
+            }
+        }
+
+        private static void WriteJsonPersonName(Utf8JsonWriter writer, DicomPersonName pn)
+        {
+            if (pn.Count != 0)
+            {
+                writer.WritePropertyName("Value");
+                writer.WriteStartArray();
+
+                foreach (var val in pn.Get<string[]>())
+                {
+                    if (string.IsNullOrEmpty(val))
+                    {
+                        writer.WriteNullValue();
+                    }
+                    else
+                    {
+                        var componentGroupValues = val.Split(_personNameComponentGroupDelimiter);
+                        int i = 0;
+
+                        writer.WriteStartObject();
+                        foreach (var componentGroupValue in componentGroupValues)
+                        {
+                            // Based on standard http://dicom.nema.org/dicom/2013/output/chtml/part18/sect_F.2.html
+                            // 1. Empty values are skipped
+                            // 2. Leading componentGroups even if null need to have delimiters. Trailing componentGroup delimiter can be omitted
+                            if (!string.IsNullOrWhiteSpace(componentGroupValue))
+                            {
+                                writer.WritePropertyName(_personNameComponentGroupNames[i]);
+                                writer.WriteStringValue(componentGroupValue);
+                            }
+                            i++;
+                        }
+                        writer.WriteEndObject();
+                    }
+                }
+
+                writer.WriteEndArray();
+            }
+        }
+
+        #endregion WriteJson helpers
+
+        #region ReadJson helpers
+
+        private DicomItem ReadJsonDicomItem(DicomTag tag, ref Utf8JsonReader reader)
+        {
+            reader.AssumeAndSkip(JsonTokenType.StartObject);
+            var currentDepth = reader.CurrentDepth;
+
+            reader.Assume(JsonTokenType.PropertyName);
+
+            string vr;
+            var property = reader.GetString();
+            if (property == "vr")
+            {
+                reader.Read();
+                vr = reader.GetString();
+                reader.Read();
+            }
+            else
+            {
+                vr = FindValue(reader, "vr", "none");
+            }
+
+            if (vr == "none") { throw new JsonException("Malformed DICOM json. vr value missing"); }
+
+            object data = vr switch
+            {
+                "OB" or "OD" or "OF" or "OL" or "OW" or "OV" or "UN" => ReadJsonOX(ref reader),
+                "SQ" => ReadJsonSequence(ref reader),
+                "PN" => ReadJsonPersonName(ref reader),
+                "FL" => ReadJsonMultiNumber(ref reader, r => r.GetSingle()),
+                "FD" => ReadJsonMultiNumber(ref reader, r => r.GetDouble()),
+                "IS" => ReadJsonMultiNumberOrString(ref reader, r => r.GetInt32(), TryParseInt),
+                "SL" => ReadJsonMultiNumber(ref reader, r => r.GetInt32()),
+                "SS" => ReadJsonMultiNumber(ref reader, r => r.GetInt16()),
+                "SV" => ReadJsonMultiNumberOrString(ref reader, r => r.GetInt64(), TryParseLong),
+                "UL" => ReadJsonMultiNumber(ref reader, r => r.GetUInt32()),
+                "US" => ReadJsonMultiNumber(ref reader, r => r.GetUInt16()),
+                "UV" => ReadJsonMultiNumberOrString(ref reader, r => r.GetUInt64(), TryParseULong),
+                "DS" => ReadJsonMultiNumberOrString(ref reader, r => r.GetDecimal(), TryParseDecimal),
+                _ => ReadJsonMultiString(ref reader),
+            };
+
+            // move to the end of the object
+            while (reader.CurrentDepth >= currentDepth && reader.Read())
+            {
+                // skip this data
+            }
+            reader.AssumeAndSkip(JsonTokenType.EndObject);
+
+            DicomItem item = CreateDicomItem(tag, vr, data);
+            return item;
+        }
+
+        private object ReadJsonMultiString(ref Utf8JsonReader reader)
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                return Array.Empty<string>();
+            }
+            string propertyname = ReadPropertyName(ref reader);
+
+            if (propertyname == "Value")
+            {
+                return ReadJsonMultiStringValue(ref reader);
+            }
+            else if (propertyname == "BulkDataURI")
+            {
+                // JToken bulk
+                return ReadJsonBulkDataUri(ref reader);
+            }
+            else
+            {
+                return Array.Empty<string>();
+            }
+        }
+
+        private static string ReadPropertyName(ref Utf8JsonReader reader)
+        {
+            reader.Assume(JsonTokenType.PropertyName);
+            var propertyname = reader.GetString();
+            reader.Read();
+            return propertyname;
+        }
+
+        private static string[] ReadJsonMultiStringValue(ref Utf8JsonReader reader)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                reader.Read();
+                return Array.Empty<string>();
+            }
+            reader.AssumeAndSkip(JsonTokenType.StartArray);
+            var childStrings = new List<string>();
+
+            while (reader.TokenType != JsonTokenType.EndArray)
+            {
+                if (reader.TokenType == JsonTokenType.Null)
+                {
+                    childStrings.Add(null);
+                }
+                else if (reader.TokenType == JsonTokenType.String)
+                {
+                    childStrings.Add(reader.GetString());
+                }
+                else
+                {
+                    // TODO: invalid. handle this?
+                }
+                reader.Read();
+            }
+            reader.AssumeAndSkip(JsonTokenType.EndArray);
+            var data = childStrings.ToArray();
+            return data;
+        }
+
+        private object ReadJsonMultiNumberOrString<T>(ref Utf8JsonReader reader, GetValue<T> getValue, TryParse<T> tryParse)
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                return Array.Empty<T>();
+            }
+            string propertyname = ReadPropertyName(ref reader);
+
+            if (propertyname == "Value")
+            {
+                return ReadJsonMultiNumberOrStringValue<T>(ref reader, getValue, tryParse);
+            }
+            else if (propertyname == "BulkDataURI")
+            {
+                return ReadJsonBulkDataUri(ref reader);
+            }
+            else
+            {
+                return Array.Empty<T>();
+            }
+        }
+
+        private static T[] ReadJsonMultiNumberOrStringValue<T>(ref Utf8JsonReader reader, GetValue<T> getValue, TryParse<T> tryParse)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                reader.Read();
+                return Array.Empty<T>();
+            }
+            reader.AssumeAndSkip(JsonTokenType.StartArray);
+
+            var childValues = new List<T>();
+            while (reader.TokenType != JsonTokenType.EndArray)
+            {
+                if (reader.TokenType == JsonTokenType.Number)
+                {
+                    childValues.Add(getValue(reader));
+                }
+                else if (reader.TokenType == JsonTokenType.String && reader.GetString() == "NaN")
+                {
+                    childValues.Add((T)(float.NaN as object));
+                }
+                else if (reader.TokenType == JsonTokenType.String && tryParse(reader.GetString(), out T parsed))
+                {
+                    childValues.Add(parsed);
+                }
+                else
+                {
+                    throw new JsonException("Malformed DICOM json, number expected");
+                }
+                reader.Read();
+            }
+            reader.AssumeAndSkip(JsonTokenType.EndArray);
+
+            var data = childValues.ToArray();
+            return data;
+        }
+
+        private object ReadJsonMultiNumber<T>(ref Utf8JsonReader reader, GetValue<T> getValue)
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                return Array.Empty<T>();
+            }
+            string propertyname = ReadPropertyName(ref reader);
+
+            if (propertyname == "Value")
+            {
+                return ReadJsonMultiNumberValue<T>(ref reader, getValue);
+            }
+            else if (propertyname == "BulkDataURI")
+            {
+                return ReadJsonBulkDataUri(ref reader);
+            }
+            else
+            {
+                return Array.Empty<T>();
+            }
+        }
+
+        private static T[] ReadJsonMultiNumberValue<T>(ref Utf8JsonReader reader, GetValue<T> getValue)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                reader.Read();
+                return Array.Empty<T>();
+            }
+            reader.AssumeAndSkip(JsonTokenType.StartArray);
+
+            var childValues = new List<T>();
+            while (reader.TokenType != JsonTokenType.EndArray)
+            {
+                if (reader.TokenType == JsonTokenType.Number)
+                {
+                    childValues.Add(getValue(reader));
+                }
+                else if (reader.TokenType == JsonTokenType.String && reader.GetString() == "NaN")
+                {
+                    childValues.Add((T)(float.NaN as object));
+                }
+                else
+                {
+                    throw new JsonException("Malformed DICOM json, number expected");
+                }
+                reader.Read();
+            }
+            reader.AssumeAndSkip(JsonTokenType.EndArray);
+
+            var data = childValues.ToArray();
+            return data;
+        }
+
+        private static string[] ReadJsonPersonName(ref Utf8JsonReader reader)
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                return Array.Empty<string>();
+            }
+            var propertyName = ReadPropertyName(ref reader);
+
+            if (propertyName == "Value")
+            {
+                if (reader.TokenType == JsonTokenType.Null)
+                {
+                    reader.Read();
+                    return Array.Empty<string>();
+                }
+                else
+                {
+                    reader.AssumeAndSkip(JsonTokenType.StartArray);
+
+                    var childStrings = new List<string>();
+                    while (reader.TokenType != JsonTokenType.EndArray)
+                    {
+                        if (reader.TokenType == JsonTokenType.Null)
+                        {
+                            reader.Read();
+                            childStrings.Add(null);
+                        }
+                        else if (reader.TokenType == JsonTokenType.StartObject)
+                        {
+                            // parse
+                            reader.Read(); // read into object
+                            var componentGroupCount = 3;
+                            var componentGroupValues = new string[componentGroupCount];
+                            while (reader.TokenType != JsonTokenType.EndObject)
+                            {
+                                if (reader.TokenType == JsonTokenType.PropertyName
+                                    && reader.GetString() == "Alphabetic")
+                                {
+                                    reader.Read(); // skip propertyname
+                                    componentGroupValues[0] = reader.GetString(); // read value
+                                }
+                                else if (reader.TokenType == JsonTokenType.PropertyName
+                                    && reader.GetString() == "Ideographic")
+                                {
+                                    reader.Read(); // skip propertyname
+                                    componentGroupValues[1] = reader.GetString(); // read value
+                                }
+                                else if (reader.TokenType == JsonTokenType.PropertyName
+                                    && reader.GetString() == "Phonetic")
+                                {
+                                    reader.Read(); // skip propertyname
+                                    componentGroupValues[2] = reader.GetString(); // read value
+                                }
+                                reader.Read();
+                            }
+
+                            //build
+                            var stringBuilder = new StringBuilder();
+                            for (int i = 0; i < componentGroupCount; i++)
+                            {
+                                var val = componentGroupValues[i];
+
+                                if (!string.IsNullOrWhiteSpace(val))
+                                {
+                                    stringBuilder.Append(val);
+                                }
+                                stringBuilder.Append(_personNameComponentGroupDelimiter);
+                            }
+
+                            //remove optional trailing delimiters
+                            string pnVal = stringBuilder.ToString().TrimEnd(_personNameComponentGroupDelimiter);
+
+                            childStrings.Add(pnVal); // add value
+                            reader.AssumeAndSkip(JsonTokenType.EndObject);
+                        }
+                        else
+                        {
+                            // TODO: invalid. handle this?
+                        }
+                    }
+                    reader.AssumeAndSkip(JsonTokenType.EndArray);
+                    var data = childStrings.ToArray();
+                    return data;
+                }
+            }
+            else
+            {
+                throw new JsonException("Malformed DICOM json, property 'Value' expected");
+            }
+        }
+
+        private DicomDataset[] ReadJsonSequence(ref Utf8JsonReader reader)
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                return Array.Empty<DicomDataset>();
+            }
+            var propertyName = ReadPropertyName(ref reader);
+
+            if (propertyName == "Value")
+            {
+                reader.AssumeAndSkip(JsonTokenType.StartArray);
+                var childItems = new List<DicomDataset>();
+                while (reader.TokenType != JsonTokenType.EndArray)
+                {
+                    if (reader.TokenType == JsonTokenType.Null)
+                    {
+                        reader.Read();
+                        childItems.Add(null);
+                    }
+                    else if (reader.TokenType == JsonTokenType.StartObject)
+                    {
+                        childItems.Add(ReadJsonDataset(ref reader));
+                        reader.AssumeAndSkip(JsonTokenType.EndObject);
+                    }
+                    else
+                    {
+                        throw new JsonException("Malformed DICOM json, object expected");
+                    }
+                }
+                reader.AssumeAndSkip(JsonTokenType.EndArray);
+                var data = childItems.ToArray();
+                return data;
+            }
+            else
+            {
+                return Array.Empty<DicomDataset>();
+            }
+        }
+
+        private IByteBuffer ReadJsonOX(ref Utf8JsonReader reader)
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                return EmptyBuffer.Value;
+            }
+            var propertyName = ReadPropertyName(ref reader);
+
+            if (propertyName == "InlineBinary")
+            {
+                return ReadJsonInlineBinary(ref reader);
+            }
+            else if (propertyName == "BulkDataURI")
+            {
+                return ReadJsonBulkDataUri(ref reader);
+            }
+            return EmptyBuffer.Value;
+        }
+
+        private static IByteBuffer ReadJsonInlineBinary(ref Utf8JsonReader reader)
+        {
+            reader.AssumeAndSkip(JsonTokenType.StartArray);
+            if (reader.TokenType != JsonTokenType.String) { throw new JsonException("Malformed DICOM json. string expected"); }
+            var data = new MemoryByteBuffer(reader.GetBytesFromBase64());
+            reader.Read();
+            reader.AssumeAndSkip(JsonTokenType.EndArray);
+            return data;
+        }
+
+        private IBulkDataUriByteBuffer ReadJsonBulkDataUri(ref Utf8JsonReader reader)
+        {
+            if (reader.TokenType != JsonTokenType.String) { throw new JsonException("Malformed DICOM json. string expected"); }
+            var data = CreateBulkDataUriByteBuffer(reader.GetString());
+            reader.Read();
+            return data;
+        }
+
+        #endregion ReadJson helpers
+
+        private static string FindValue(Utf8JsonReader reader, string property, string defaultValue)
+        {
+            var currentDepth = reader.CurrentDepth;
+            while (reader.CurrentDepth >= currentDepth)
+            {
+                if (reader.CurrentDepth == currentDepth
+                    && reader.TokenType == JsonTokenType.PropertyName
+                    && reader.GetString() == property)
+                {
+                    reader.Read(); // move to value
+                    return reader.GetString();
+                }
+                reader.Read();
+            }
+            return defaultValue;
+        }
+
+        private static bool TryParseInt(string value, out int parsed)
+            => int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out parsed);
+
+        private static bool TryParseDecimal(string value, out decimal parsed)
+            => decimal.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out parsed);
+
+        private static bool TryParseDouble(string value, out double parsed)
+            => double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out parsed);
+
+        private static bool TryParseLong(string value, out long parsed)
+            => long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out parsed);
+
+        private static bool TryParseULong(string value, out ulong parsed)
+            => ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out parsed);
+    }
+
+
+    internal static class JsonDicomConverterExtensions
+    {
+
+        public static string[] GetAsStringArray(this object data) => (string[])data;
+
+        public static string GetFirstOrEmpty(this string[] array) => array.Length > 0 ? array[0] : string.Empty;
+
+        public static string GetSingleOrEmpty(this string[] array) => array.Length > 0 ? array.Single() : string.Empty;
+
+    }
+
+    internal static class Utf8JsonReaderExtensions
+    {
+        public static void Assume(this ref Utf8JsonReader reader, JsonTokenType tokenType)
+        {
+            if (reader.TokenType != tokenType)
+            {
+                throw new JsonException($"invalid: {tokenType} expected at position {reader.TokenStartIndex}, instead found {reader.TokenType}");
+            }
+        }
+
+        public static void AssumeAndSkip(this ref Utf8JsonReader reader, JsonTokenType tokenType)
+        {
+            Assume(ref reader, tokenType);
+            reader.Read();
+        }
+    }
+}

--- a/src/InformaticsGateway/Program.cs
+++ b/src/InformaticsGateway/Program.cs
@@ -50,11 +50,9 @@ namespace Monai.Deploy.InformaticsGateway
         {
             Guard.Against.Null(host, nameof(host));
 
-            using (var serviceScope = host.Services.CreateScope())
-            {
-                var context = serviceScope.ServiceProvider.GetRequiredService<InformaticsGatewayContext>();
-                context.Database.Migrate();
-            }
+            using var serviceScope = host.Services.CreateScope();
+            var context = serviceScope.ServiceProvider.GetRequiredService<InformaticsGatewayContext>();
+            context.Database.Migrate();
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>

--- a/src/InformaticsGateway/Services/Connectors/PayloadAssembler.cs
+++ b/src/InformaticsGateway/Services/Connectors/PayloadAssembler.cs
@@ -76,10 +76,6 @@ namespace Monai.Deploy.InformaticsGateway.Services.Connectors
                     _logger.Log(LogLevel.Information, $"Payload {payload.Id} restored from database.");
                     restored++;
                 }
-                else
-                {
-                    _logger.Log(LogLevel.Information, $"Failed to restore payload {payload.Id} from database.");
-                }
             }
             _logger.Log(LogLevel.Information, $"{restored} paylaods restored from database.");
         }

--- a/src/InformaticsGateway/Services/Scp/ApplicationEntityHandler.cs
+++ b/src/InformaticsGateway/Services/Scp/ApplicationEntityHandler.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Logging;
 using Monai.Deploy.InformaticsGateway.Api;
 using Monai.Deploy.InformaticsGateway.Api.Storage;
 using Monai.Deploy.InformaticsGateway.Common;
+using Monai.Deploy.InformaticsGateway.Configuration;
 using Monai.Deploy.InformaticsGateway.Services.Connectors;
 using System;
 using System.Linq;
@@ -23,21 +24,24 @@ namespace Monai.Deploy.InformaticsGateway.Services.Scp
 {
     internal class ApplicationEntityHandler
     {
-        private MonaiApplicationEntity _configuration;
-        private IPayloadAssembler _payloadAssembler;
-        private IDicomToolkit _dicomToolkit;
-        private ILogger<ApplicationEntityHandler> _logger;
+        private readonly MonaiApplicationEntity _configuration;
+        private readonly IPayloadAssembler _payloadAssembler;
+        private readonly IDicomToolkit _dicomToolkit;
+        private readonly ILogger<ApplicationEntityHandler> _logger;
+        private readonly DicomJsonOptions _dicomJsonOptions;
 
         public ApplicationEntityHandler(
             MonaiApplicationEntity monaiApplicationEntity,
             IPayloadAssembler payloadAssembler,
             IDicomToolkit dicomToolkit,
-            ILogger<ApplicationEntityHandler> logger)
+            ILogger<ApplicationEntityHandler> logger,
+            DicomJsonOptions dicomJsonOptions)
         {
             _configuration = monaiApplicationEntity ?? throw new ArgumentNullException(nameof(monaiApplicationEntity));
             _payloadAssembler = payloadAssembler ?? throw new ArgumentNullException(nameof(payloadAssembler));
             _dicomToolkit = dicomToolkit ?? throw new ArgumentNullException(nameof(dicomToolkit));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _dicomJsonOptions = dicomJsonOptions;
         }
 
         internal async Task HandleInstance(DicomCStoreRequest request, DicomFileStorageInfo info)
@@ -53,7 +57,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Scp
                 info.SetWorkflows(_configuration.Workflows.ToArray());
             }
 
-            await SaveDicomInstance(request, info.FilePath);
+            await SaveDicomInstance(request, info.FilePath, info.DicomJsonFilePath);
 
             var dicomTag = FellowOakDicom.DicomTag.Parse(_configuration.Grouping);
             if (request.Dataset.TryGetSingleValue<string>(dicomTag, out string key))
@@ -62,10 +66,10 @@ namespace Monai.Deploy.InformaticsGateway.Services.Scp
             }
         }
 
-        private async Task SaveDicomInstance(DicomCStoreRequest request, string filename)
+        private async Task SaveDicomInstance(DicomCStoreRequest request, string filename, string metadataFilename)
         {
             _logger.Log(LogLevel.Debug, $"Preparing to save {filename}");
-            await _dicomToolkit.Save(request.File, filename);
+            await _dicomToolkit.Save(request.File, filename, metadataFilename, _dicomJsonOptions);
             _logger.Log(LogLevel.Information, $"Instance saved {filename}");
         }
     }

--- a/src/InformaticsGateway/Services/Scp/ApplicationEntityManager.cs
+++ b/src/InformaticsGateway/Services/Scp/ApplicationEntityManager.cs
@@ -127,13 +127,14 @@ namespace Monai.Deploy.InformaticsGateway.Services.Scp
             }
 
             var rootPath = _fileSystem.Path.Combine(Configuration.Value.Storage.TemporaryDataDirFullPath, calledAeTitle);
-            var info = new DicomFileStorageInfo(associationId.ToString(), rootPath, request.MessageID.ToString(), callingAeTitle, _fileSystem);
+            var info = new DicomFileStorageInfo(associationId.ToString(), rootPath, request.MessageID.ToString(), callingAeTitle, _fileSystem)
+            {
+                StudyInstanceUid = request.Dataset.GetSingleValue<string>(DicomTag.StudyInstanceUID),
+                SeriesInstanceUid = request.Dataset.GetSingleValue<string>(DicomTag.SeriesInstanceUID),
+                SopInstanceUid = request.Dataset.GetSingleValue<string>(DicomTag.SOPInstanceUID)
+            };
 
-            info.StudyInstanceUid = request.Dataset.GetSingleValue<string>(DicomTag.StudyInstanceUID);
-            info.SeriesInstanceUid = request.Dataset.GetSingleValue<string>(DicomTag.SeriesInstanceUID);
-            info.SopInstanceUid = request.Dataset.GetSingleValue<string>(DicomTag.SOPInstanceUID);
-
-            using (_logger.BeginScope("SOPInstanceUID={0}", info.SopInstanceUid))
+            using (_logger.BeginScope($"SOPInstanceUID={info.SopInstanceUid}"))
             {
                 _logger.Log(LogLevel.Information, "Study Instance UID: {StudyInstanceUid}", info.StudyInstanceUid);
                 _logger.Log(LogLevel.Information, "Series Instance UID: {SeriesInstanceUid}", info.SeriesInstanceUid);
@@ -172,17 +173,15 @@ namespace Monai.Deploy.InformaticsGateway.Services.Scp
 
         private void AddNewAeTitle(MonaiApplicationEntity entity)
         {
-            using (var scope = _serviceScopeFactory.CreateScope())
+            using var scope = _serviceScopeFactory.CreateScope();
+            var handler = new ApplicationEntityHandler(entity, _payloadAssembler, _dicomToolkit, _loggerFactory.CreateLogger<ApplicationEntityHandler>(), Configuration.Value.Dicom.WriteDicomJson);
+            if (!_aeTitles.TryAdd(entity.AeTitle, handler))
             {
-                var handler = new ApplicationEntityHandler(entity, _payloadAssembler, _dicomToolkit, _loggerFactory.CreateLogger<ApplicationEntityHandler>());
-                if (!_aeTitles.TryAdd(entity.AeTitle, handler))
-                {
-                    _logger.Log(LogLevel.Error, $"AE Title {0} could not be added to CStore Manager.  Already exits: {1}", entity.AeTitle, _aeTitles.ContainsKey(entity.AeTitle));
-                }
-                else
-                {
-                    _logger.Log(LogLevel.Information, $"{entity.AeTitle} added to AE Title Manager");
-                }
+                _logger.Log(LogLevel.Error, $"AE Title {0} could not be added to CStore Manager.  Already exits: {1}", entity.AeTitle, _aeTitles.ContainsKey(entity.AeTitle));
+            }
+            else
+            {
+                _logger.Log(LogLevel.Information, $"{entity.AeTitle} added to AE Title Manager");
             }
         }
 

--- a/src/InformaticsGateway/Services/Storage/SpaceReclaimerService.cs
+++ b/src/InformaticsGateway/Services/Storage/SpaceReclaimerService.cs
@@ -115,11 +115,15 @@ namespace Monai.Deploy.InformaticsGateway.Services.Storage
                     })
                 .Execute(() =>
                 {
-                    _logger.Log(LogLevel.Debug, "Deleting file {0}", file);
-                    if (_fileSystem.File.Exists(file.FilePath))
+
+                    foreach (var filePath in file.FilePaths)
                     {
-                        _fileSystem.File.Delete(file.FilePath);
-                        _logger.Log(LogLevel.Debug, "File deleted {0}", file);
+                        _logger.Log(LogLevel.Debug, $"Deleting file {filePath}");
+                        if (_fileSystem.File.Exists(filePath))
+                        {
+                            _fileSystem.File.Delete(filePath);
+                            _logger.Log(LogLevel.Debug, $"File deleted {filePath}");
+                        }
                     }
 
                     try
@@ -147,7 +151,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Storage
             {
                 try
                 {
-                    _logger.Log(LogLevel.Debug, "Deleting directory {0}", dirPath);
+                    _logger.Log(LogLevel.Debug, $"Deleting directory {dirPath}");
                     _fileSystem.Directory.Delete(dirPath);
                     RecursivelyRemoveDirectoriesIfEmpty(_fileSystem.Directory.GetParent(dirPath).FullName);
                 }

--- a/src/InformaticsGateway/Test/Services/Connectors/DataRetrievalServiceTest.cs
+++ b/src/InformaticsGateway/Test/Services/Connectors/DataRetrievalServiceTest.cs
@@ -13,9 +13,11 @@ using FellowOakDicom;
 using FellowOakDicom.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Monai.Deploy.InformaticsGateway.Api.Rest;
 using Monai.Deploy.InformaticsGateway.Api.Storage;
 using Monai.Deploy.InformaticsGateway.Common;
+using Monai.Deploy.InformaticsGateway.Configuration;
 using Monai.Deploy.InformaticsGateway.DicomWeb.Client;
 using Monai.Deploy.InformaticsGateway.Repositories;
 using Monai.Deploy.InformaticsGateway.Services.Connectors;
@@ -41,15 +43,16 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
     {
         private readonly Mock<ILoggerFactory> _loggerFactory;
         private readonly Mock<IHttpClientFactory> _httpClientFactory;
-        private Mock<ILogger<DicomWebClient>> _loggerDicomWebClient;
-        private Mock<ILogger<DataRetrievalService>> _logger;
-        private Mock<IInferenceRequestRepository> _inferenceRequestStore;
-        private Mock<IDicomToolkit> _dicomToolkit;
-        private MockFileSystem _fileSystem;
+        private readonly Mock<ILogger<DicomWebClient>> _loggerDicomWebClient;
+        private readonly Mock<ILogger<DataRetrievalService>> _logger;
+        private readonly Mock<IInferenceRequestRepository> _inferenceRequestStore;
+        private readonly Mock<IDicomToolkit> _dicomToolkit;
+        private readonly MockFileSystem _fileSystem;
         private Mock<HttpMessageHandler> _handlerMock;
         private readonly Mock<IStorageInfoProvider> _storageInfoProvider;
         private readonly Mock<IPayloadAssembler> _payloadAssembler;
         private readonly Mock<IServiceScopeFactory> _serviceScopeFactory;
+        private readonly IOptions<InformaticsGatewayConfiguration> _options;
 
         public DataRetrievalServiceTest()
         {
@@ -63,6 +66,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
             _storageInfoProvider = new Mock<IStorageInfoProvider>();
             _payloadAssembler = new Mock<IPayloadAssembler>();
             _serviceScopeFactory = new Mock<IServiceScopeFactory>();
+            _options = Options.Create(new InformaticsGatewayConfiguration());
 
             _loggerFactory.Setup(p => p.CreateLogger(It.IsAny<string>())).Returns((string type) =>
             {
@@ -83,16 +87,17 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
         [RetryFact(5, 250, DisplayName = "Constructor")]
         public void ConstructorTest()
         {
-            Assert.Throws<ArgumentNullException>(() => new DataRetrievalService(null, null, null, null, null, null, null, null));
-            Assert.Throws<ArgumentNullException>(() => new DataRetrievalService(_loggerFactory.Object, null, null, null, null, null, null, null));
-            Assert.Throws<ArgumentNullException>(() => new DataRetrievalService(_loggerFactory.Object, _httpClientFactory.Object, null, null, null, null, null, null));
-            Assert.Throws<ArgumentNullException>(() => new DataRetrievalService(_loggerFactory.Object, _httpClientFactory.Object, _logger.Object, null, null, null, null, null));
-            Assert.Throws<ArgumentNullException>(() => new DataRetrievalService(_loggerFactory.Object, _httpClientFactory.Object, _logger.Object, _fileSystem, null, null, null, null));
-            Assert.Throws<ArgumentNullException>(() => new DataRetrievalService(_loggerFactory.Object, _httpClientFactory.Object, _logger.Object, _fileSystem, _dicomToolkit.Object, null, null, null));
-            Assert.Throws<ArgumentNullException>(() => new DataRetrievalService(_loggerFactory.Object, _httpClientFactory.Object, _logger.Object, _fileSystem, _dicomToolkit.Object, _serviceScopeFactory.Object, null, null));
-            Assert.Throws<ArgumentNullException>(() => new DataRetrievalService(_loggerFactory.Object, _httpClientFactory.Object, _logger.Object, _fileSystem, _dicomToolkit.Object, _serviceScopeFactory.Object, _payloadAssembler.Object, null));
+            Assert.Throws<ArgumentNullException>(() => new DataRetrievalService(null, null, null, null, null, null, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new DataRetrievalService(_loggerFactory.Object, null, null, null, null, null, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new DataRetrievalService(_loggerFactory.Object, _httpClientFactory.Object, null, null, null, null, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new DataRetrievalService(_loggerFactory.Object, _httpClientFactory.Object, _logger.Object, null, null, null, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new DataRetrievalService(_loggerFactory.Object, _httpClientFactory.Object, _logger.Object, _fileSystem, null, null, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new DataRetrievalService(_loggerFactory.Object, _httpClientFactory.Object, _logger.Object, _fileSystem, _dicomToolkit.Object, null, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new DataRetrievalService(_loggerFactory.Object, _httpClientFactory.Object, _logger.Object, _fileSystem, _dicomToolkit.Object, _serviceScopeFactory.Object, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new DataRetrievalService(_loggerFactory.Object, _httpClientFactory.Object, _logger.Object, _fileSystem, _dicomToolkit.Object, _serviceScopeFactory.Object, _payloadAssembler.Object, null, null));
+            Assert.Throws<ArgumentNullException>(() => new DataRetrievalService(_loggerFactory.Object, _httpClientFactory.Object, _logger.Object, _fileSystem, _dicomToolkit.Object, _serviceScopeFactory.Object, _payloadAssembler.Object, _storageInfoProvider.Object, null));
 
-            new DataRetrievalService(
+            _ = new DataRetrievalService(
                 _loggerFactory.Object,
                 _httpClientFactory.Object,
                 _logger.Object,
@@ -100,7 +105,8 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
                 _dicomToolkit.Object,
                 _serviceScopeFactory.Object,
                 _payloadAssembler.Object,
-                _storageInfoProvider.Object);
+                _storageInfoProvider.Object,
+                _options);
         }
 
         [RetryFact(5, 250, DisplayName = "Cancellation token shall stop the service")]
@@ -119,7 +125,8 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
                 _dicomToolkit.Object,
                 _serviceScopeFactory.Object,
                 _payloadAssembler.Object,
-                _storageInfoProvider.Object);
+                _storageInfoProvider.Object,
+                _options);
 
             await store.StartAsync(cancellationTokenSource.Token);
             Thread.Sleep(250);
@@ -148,7 +155,8 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
                 _dicomToolkit.Object,
                 _serviceScopeFactory.Object,
                 _payloadAssembler.Object,
-                _storageInfoProvider.Object);
+                _storageInfoProvider.Object,
+                _options);
 
             await store.StartAsync(cancellationTokenSource.Token);
             Thread.Sleep(250);
@@ -251,7 +259,8 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
                 _dicomToolkit.Object,
                 _serviceScopeFactory.Object,
                 _payloadAssembler.Object,
-                _storageInfoProvider.Object);
+                _storageInfoProvider.Object,
+                _options);
 
             await store.StartAsync(cancellationTokenSource.Token);
 
@@ -333,7 +342,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
 
             request.ConfigureTemporaryStorageLocation(storagePath);
 
-            _dicomToolkit.Setup(p => p.Save(It.IsAny<DicomFile>(), It.IsAny<string>()));
+            _dicomToolkit.Setup(p => p.Save(It.IsAny<DicomFile>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DicomJsonOptions>()));
 
             _inferenceRequestStore.SetupSequence(p => p.Take(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(request))
@@ -370,7 +379,8 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
                 _dicomToolkit.Object,
                 _serviceScopeFactory.Object,
                 _payloadAssembler.Object,
-                _storageInfoProvider.Object);
+                _storageInfoProvider.Object,
+                _options);
 
             await store.StartAsync(cancellationTokenSource.Token);
 
@@ -384,7 +394,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
                 req.RequestUri.ToString().StartsWith($"{url}studies/")),
                ItExpr.IsAny<CancellationToken>());
 
-            _dicomToolkit.Verify(p => p.Save(It.IsAny<DicomFile>(), It.IsAny<string>()), Times.Never());
+            _dicomToolkit.Verify(p => p.Save(It.IsAny<DicomFile>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DicomJsonOptions>()), Times.Never());
             _storageInfoProvider.Verify(p => p.HasSpaceAvailableToRetrieve, Times.AtLeastOnce());
             _storageInfoProvider.Verify(p => p.AvailableFreeSpace, Times.Never());
             _payloadAssembler.Verify(p => p.Queue(It.IsAny<string>(), It.IsAny<FileStorageInfo>()), Times.Never());
@@ -475,7 +485,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
 
             request.ConfigureTemporaryStorageLocation(storagePath);
 
-            _dicomToolkit.Setup(p => p.Save(It.IsAny<DicomFile>(), It.IsAny<string>()));
+            _dicomToolkit.Setup(p => p.Save(It.IsAny<DicomFile>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DicomJsonOptions>()));
 
             _inferenceRequestStore.SetupSequence(p => p.Take(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(request))
@@ -510,7 +520,8 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
                 _dicomToolkit.Object,
                 _serviceScopeFactory.Object,
                 _payloadAssembler.Object,
-                _storageInfoProvider.Object);
+                _storageInfoProvider.Object,
+                _options);
 
             await store.StartAsync(cancellationTokenSource.Token);
 
@@ -524,7 +535,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
                 req.RequestUri.ToString().StartsWith($"{url}studies/")),
                ItExpr.IsAny<CancellationToken>());
 
-            _dicomToolkit.Verify(p => p.Save(It.IsAny<DicomFile>(), It.IsAny<string>()), Times.Exactly(4));
+            _dicomToolkit.Verify(p => p.Save(It.IsAny<DicomFile>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DicomJsonOptions>()), Times.Exactly(4));
             _storageInfoProvider.Verify(p => p.HasSpaceAvailableToRetrieve, Times.AtLeastOnce());
             _storageInfoProvider.Verify(p => p.AvailableFreeSpace, Times.Never());
             _payloadAssembler.Verify(p => p.Queue(It.IsAny<string>(), It.IsAny<FileStorageInfo>()), Times.Exactly(4));
@@ -576,7 +587,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
 
             request.ConfigureTemporaryStorageLocation(storagePath);
 
-            _dicomToolkit.Setup(p => p.Save(It.IsAny<DicomFile>(), It.IsAny<string>()));
+            _dicomToolkit.Setup(p => p.Save(It.IsAny<DicomFile>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DicomJsonOptions>()));
 
             _inferenceRequestStore.SetupSequence(p => p.Take(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(request))
@@ -624,7 +635,8 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
                 _dicomToolkit.Object,
                 _serviceScopeFactory.Object,
                 _payloadAssembler.Object,
-                _storageInfoProvider.Object);
+                _storageInfoProvider.Object,
+                _options);
 
             await store.StartAsync(cancellationTokenSource.Token);
 
@@ -649,7 +661,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
                    ItExpr.IsAny<CancellationToken>());
             }
 
-            _dicomToolkit.Verify(p => p.Save(It.IsAny<DicomFile>(), It.IsAny<string>()), Times.Exactly(studyInstanceUids.Count));
+            _dicomToolkit.Verify(p => p.Save(It.IsAny<DicomFile>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DicomJsonOptions>()), Times.Exactly(studyInstanceUids.Count));
             _storageInfoProvider.Verify(p => p.HasSpaceAvailableToRetrieve, Times.AtLeastOnce());
             _storageInfoProvider.Verify(p => p.AvailableFreeSpace, Times.Never());
             _payloadAssembler.Verify(p => p.Queue(It.IsAny<string>(), It.IsAny<FileStorageInfo>()), Times.Exactly(studyInstanceUids.Count));
@@ -701,7 +713,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
 
             request.ConfigureTemporaryStorageLocation(storagePath);
 
-            _dicomToolkit.Setup(p => p.Save(It.IsAny<DicomFile>(), It.IsAny<string>()));
+            _dicomToolkit.Setup(p => p.Save(It.IsAny<DicomFile>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DicomJsonOptions>()));
 
             _inferenceRequestStore.SetupSequence(p => p.Take(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(request))
@@ -749,7 +761,8 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
                 _dicomToolkit.Object,
                 _serviceScopeFactory.Object,
                 _payloadAssembler.Object,
-                _storageInfoProvider.Object);
+                _storageInfoProvider.Object,
+                _options);
 
             await store.StartAsync(cancellationTokenSource.Token);
 
@@ -774,7 +787,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
                    ItExpr.IsAny<CancellationToken>());
             }
 
-            _dicomToolkit.Verify(p => p.Save(It.IsAny<DicomFile>(), It.IsAny<string>()), Times.Exactly(studyInstanceUids.Count));
+            _dicomToolkit.Verify(p => p.Save(It.IsAny<DicomFile>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DicomJsonOptions>()), Times.Exactly(studyInstanceUids.Count));
             _storageInfoProvider.Verify(p => p.HasSpaceAvailableToRetrieve, Times.AtLeastOnce());
             _storageInfoProvider.Verify(p => p.AvailableFreeSpace, Times.Never());
             _payloadAssembler.Verify(p => p.Queue(It.IsAny<string>(), It.IsAny<FileStorageInfo>()), Times.Exactly(2));
@@ -878,7 +891,8 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
                 _dicomToolkit.Object,
                 _serviceScopeFactory.Object,
                 _payloadAssembler.Object,
-                _storageInfoProvider.Object);
+                _storageInfoProvider.Object,
+                _options);
 
             await store.StartAsync(cancellationTokenSource.Token);
 
@@ -904,14 +918,16 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
             _payloadAssembler.Verify(p => p.Queue(It.IsAny<string>(), It.IsAny<FileStorageInfo>()), Times.Exactly(2));
         }
 
-        private HttpResponseMessage GenerateQueryResult(DicomTag dicomTag, string queryValue, List<string> studyInstanceUids)
+        private static HttpResponseMessage GenerateQueryResult(DicomTag dicomTag, string queryValue, List<string> studyInstanceUids)
         {
             var set = new List<string>();
             foreach (var studyInstanceUid in studyInstanceUids)
             {
-                var dataset = new DicomDataset();
-                dataset.Add(dicomTag, queryValue);
-                dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
+                var dataset = new DicomDataset
+                {
+                    { dicomTag, queryValue },
+                    { DicomTag.StudyInstanceUID, studyInstanceUid }
+                };
                 set.Add(DicomJson.ConvertDicomToJson(dataset));
             }
             var json = JsonConvert.SerializeObject(set);
@@ -919,7 +935,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
             return new HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = stringContent };
         }
 
-        private HttpResponseMessage GenerateMultipartResponse()
+        private static HttpResponseMessage GenerateMultipartResponse()
         {
             var data = InstanceGenerator.GenerateDicomData();
             var content = new MultipartContent("related");
@@ -930,7 +946,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
             return new HttpResponseMessage() { Content = content };
         }
 
-        private void BlockUntilCancelled(CancellationToken token)
+        private static void BlockUntilCancelled(CancellationToken token)
         {
             WaitHandle.WaitAll(new[] { token.WaitHandle });
         }


### PR DESCRIPTION
Fixes #36
### Description

- convert and store DICOM to JSON format.
  - An enhancement has been filed with [fo-dicom](https://github.com/fo-dicom/fo-dicom/issues/1321) to support the option of not writing `other` value types.  Until then, a copy of the code is included.
- update WorkflowRequestMessage structure

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] All tests passed locally by running `./src/run-tests-in-docker.sh`.
- [x] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [x] User guide updated.
- [ ] I have updated the changelog
