### PR TITLE
Fix typos in ConfigurationKeyName

### DIFF
--- a/src/Configuration/DataExportConfiguration.cs
+++ b/src/Configuration/DataExportConfiguration.cs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: © 2019-2021 NVIDIA Corporation
 // SPDX-License-Identifier: Apache License 2.0
 
-using Newtonsoft.Json;
+using Microsoft.Extensions.Configuration;
 
 namespace Monai.Deploy.InformaticsGateway.Configuration
 {
@@ -11,7 +11,7 @@ namespace Monai.Deploy.InformaticsGateway.Configuration
         /// <summary>
         /// Gets or sets retry configuration for data export agents.
         /// </summary>
-        [JsonProperty(PropertyName = "retries")]
+        [ConfigurationKeyName("retries")]
         public RetryConfiguration Retries { get; set; } = new RetryConfiguration();
     }
 }

--- a/src/Configuration/DicomConfiguration.cs
+++ b/src/Configuration/DicomConfiguration.cs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: © 2019-2020 NVIDIA Corporation
 // SPDX-License-Identifier: Apache License 2.0
 
-using Newtonsoft.Json;
+using Microsoft.Extensions.Configuration;
 
 namespace Monai.Deploy.InformaticsGateway.Configuration
 {
@@ -14,19 +14,19 @@ namespace Monai.Deploy.InformaticsGateway.Configuration
         /// <summary>
         /// Represents the <c>dicom>scp</c> section of the configuration file.
         /// </summary>
-        [JsonProperty(PropertyName = "scp")]
+        [ConfigurationKeyName("scp")]
         public ScpConfiguration Scp { get; set; } = new ScpConfiguration();
 
         /// <summary>
         /// Represents the <c>dicom>scu</c> section of the configuration file.
         /// </summary>
-        [JsonProperty(PropertyName = "scu")]
+        [ConfigurationKeyName("scu")]
         public ScuConfiguration Scu { get; set; } = new ScuConfiguration();
 
         /// <summary>
         /// Gets or sets whether to write DICOM JSON file for each instance received.
         /// </summary>
-        [JsonProperty(PropertyName = "writeDicomJson")]
+        [ConfigurationKeyName("writeDicomJson")]
         public DicomJsonOptions WriteDicomJson { get; set; } = DicomJsonOptions.IgnoreOthers;
     }
 }

--- a/src/Configuration/DicomWebConfiguration.cs
+++ b/src/Configuration/DicomWebConfiguration.cs
@@ -1,7 +1,7 @@
 ﻿// SPDX-FileCopyrightText: © 2021-2022 MONAI Consortium
 // SPDX-License-Identifier: Apache License 2.0
 
-using Newtonsoft.Json;
+using Microsoft.Extensions.Configuration;
 
 namespace Monai.Deploy.InformaticsGateway.Configuration
 {
@@ -12,20 +12,20 @@ namespace Monai.Deploy.InformaticsGateway.Configuration
         /// <summary>
         /// Gets or sets the client connection timeout in seconds.
         /// </summary>
-        [JsonProperty(PropertyName = "clientTimeout")]
+        [ConfigurationKeyName("clientTimeout")]
         public int ClientTimeoutSeconds { get; set; } = DefaultClientTimeout;
 
         /// <summary>
         /// Gets or sets the (postfix) name of the DICOMweb export agent used for receiving messages.
         /// The agent name is combine with <see cref="MessageBrokerConfigurationKeys.ExportRequestPrefix"/>
         /// for subscribing messages from the message broker service.
-        [JsonProperty(PropertyName = "agentName")]
+        [ConfigurationKeyName("agentName")]
         public string AgentName { get; set; } = "monaidicomweb";
 
         /// <summary>
         /// Gets or sets the maximum number of simultaneous DICOMweb connections.
         /// </summary>
-        [JsonProperty(PropertyName = "maximumNumberOfConnections")]
+        [ConfigurationKeyName("maximumNumberOfConnections")]
         public int MaximumNumberOfConnection { get; set; } = 2;
 
         public DicomWebConfiguration()

--- a/src/Configuration/FhirConfiguration.cs
+++ b/src/Configuration/FhirConfiguration.cs
@@ -1,7 +1,7 @@
 ﻿// SPDX-FileCopyrightText: © 2021-2022 MONAI Consortium
 // SPDX-License-Identifier: Apache License 2.0
 
-using Newtonsoft.Json;
+using Microsoft.Extensions.Configuration;
 
 namespace Monai.Deploy.InformaticsGateway.Configuration
 {
@@ -12,7 +12,7 @@ namespace Monai.Deploy.InformaticsGateway.Configuration
         /// <summary>
         /// Gets or sets the client connection timeout in seconds.
         /// </summary>
-        [JsonProperty(PropertyName = "clientTimeout")]
+        [ConfigurationKeyName("clientTimeout")]
         public int ClientTimeoutSeconds { get; set; } = DefaultClientTimeout;
 
         public FhirConfiguration()

--- a/src/Configuration/InformaticsGatewayConfiguration.cs
+++ b/src/Configuration/InformaticsGatewayConfiguration.cs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: © 2019-2021 NVIDIA Corporation
 // SPDX-License-Identifier: Apache License 2.0
 
-using Newtonsoft.Json;
+using Microsoft.Extensions.Configuration;
 
 namespace Monai.Deploy.InformaticsGateway.Configuration
 {
@@ -19,40 +19,40 @@ namespace Monai.Deploy.InformaticsGateway.Configuration
         /// <summary>
         /// Represents the <c>dicom</c> section of the configuration file.
         /// </summary>
-        [JsonProperty(PropertyName = "dicom")]
+        [ConfigurationKeyName("dicom")]
         public DicomConfiguration Dicom { get; set; }
 
         /// <summary>
         /// Represents the <c>storage</c> section of the configuration file.
         /// </summary>
         /// <value></value>
-        [JsonProperty(PropertyName = "storage")]
+        [ConfigurationKeyName("storage")]
         public StorageConfiguration Storage { get; set; }
 
         /// <summary>
         /// Represents the <c>dicomWeb</c> section of the configuration file.
         /// </summary>
         /// <value></value>
-        [JsonProperty(PropertyName = "dicomWeb")]
+        [ConfigurationKeyName("dicomWeb")]
         public DicomWebConfiguration DicomWeb { get; set; }
 
         /// <summary>
         /// Represents the <c>fhir</c> section of the configuration file.
         /// </summary>
         /// <value></value>
-        [JsonProperty(PropertyName = "fhir")]
+        [ConfigurationKeyName("fhir")]
         public FhirConfiguration Fhir { get; set; }
 
         /// <summary>
         /// Represents the <c>export</c> section of the configuration file.
         /// </summary>
-        [JsonProperty(PropertyName = "export")]
+        [ConfigurationKeyName("export")]
         public DataExportConfiguration Export { get; set; }
 
         /// <summary>
         /// Represents the <c>messaging</c> section of the configuration file.
         /// </summary>
-        [JsonProperty(PropertyName = "messaging")]
+        [ConfigurationKeyName("messaging")]
         public MessageBrokerConfiguration Messaging { get; set; }
 
         public InformaticsGatewayConfiguration()

--- a/src/Configuration/MessageBrokerConfiguration.cs
+++ b/src/Configuration/MessageBrokerConfiguration.cs
@@ -1,8 +1,8 @@
 ﻿// SPDX-FileCopyrightText: © 2021-2022 MONAI Consortium
 // SPDX-License-Identifier: Apache License 2.0
 
+using Microsoft.Extensions.Configuration;
 using Monai.Deploy.Messaging.Configuration;
-using Newtonsoft.Json;
 
 namespace Monai.Deploy.InformaticsGateway.Configuration
 {
@@ -13,13 +13,13 @@ namespace Monai.Deploy.InformaticsGateway.Configuration
         /// <summary>
         /// Gets or sets retry options relate to the message broker services.
         /// </summary>
-        [JsonProperty(PropertyName = "retries")]
+        [ConfigurationKeyName("retries")]
         public RetryConfiguration Retries { get; set; } = new RetryConfiguration();
 
         /// <summary>
         /// Gets or sets the topics for events published/subscribed by Informatics Gateway
         /// </summary>
-        [JsonProperty(PropertyName = "topics")]
+        [ConfigurationKeyName("topics")]
         public MessageBrokerConfigurationKeys Topics { get; set; } = new MessageBrokerConfigurationKeys();
     }
 }

--- a/src/Configuration/MessageBrokerConfiguration.cs
+++ b/src/Configuration/MessageBrokerConfiguration.cs
@@ -13,7 +13,7 @@ namespace Monai.Deploy.InformaticsGateway.Configuration
         /// <summary>
         /// Gets or sets retry options relate to the message broker services.
         /// </summary>
-        [JsonProperty(PropertyName = "reties")]
+        [JsonProperty(PropertyName = "retries")]
         public RetryConfiguration Retries { get; set; } = new RetryConfiguration();
 
         /// <summary>

--- a/src/Configuration/MessageBrokerConfigurationKeys.cs
+++ b/src/Configuration/MessageBrokerConfigurationKeys.cs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: © 2021-2022 MONAI Consortium
 // SPDX-License-Identifier: Apache License 2.0
 
-using Newtonsoft.Json;
+using Microsoft.Extensions.Configuration;
 
 namespace Monai.Deploy.InformaticsGateway.Configuration
 {
@@ -11,21 +11,21 @@ namespace Monai.Deploy.InformaticsGateway.Configuration
         /// Gets or sets the topic for publishing workflow requests.
         /// Defaults to `md_workflow_request`.
         /// </summary>
-        [JsonProperty(PropertyName = "workflowRequest")]
+        [ConfigurationKeyName("workflowRequest")]
         public string WorkflowRequest { get; set; } = "md.workflow.request";
 
         /// <summary>
         /// Gets or sets the topic for publishing workflow requests.
         /// Defaults to `md_workflow_request`.
         /// </summary>
-        [JsonProperty(PropertyName = "exportComplete")]
+        [ConfigurationKeyName("exportComplete")]
         public string ExportComplete { get; set; } = "md.export.complete";
 
         /// <summary>
         /// Gets or sets the topic for publishing workflow requests.
         /// Defaults to `md_workflow_request`.
         /// </summary>
-        [JsonProperty(PropertyName = "exportRequestPrefix")]
+        [ConfigurationKeyName("exportRequestPrefix")]
         public string ExportRequestPrefix { get; set; } = "md.export.request";
     }
 }

--- a/src/Configuration/RetryConfiguration.cs
+++ b/src/Configuration/RetryConfiguration.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using Microsoft.Extensions.Configuration;
 
 namespace Monai.Deploy.InformaticsGateway.Configuration
 {
@@ -15,7 +15,7 @@ namespace Monai.Deploy.InformaticsGateway.Configuration
         /// Values can be separated by commas.
         /// Default is 250, 500, 1000.
         /// </summary>
-        [JsonProperty(PropertyName = "delays")]
+        [ConfigurationKeyName("delays")]
         public int[] DelaysMilliseconds { get; set; } = new[] { 250, 500, 1000 };
 
         // Gets the delays in TimeSpan objects

--- a/src/Configuration/ScpConfiguration.cs
+++ b/src/Configuration/ScpConfiguration.cs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache License 2.0
 
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using Microsoft.Extensions.Configuration;
 
 namespace Monai.Deploy.InformaticsGateway.Configuration
 {
@@ -18,31 +18,31 @@ namespace Monai.Deploy.InformaticsGateway.Configuration
         /// <summary>
         /// Gets or sets Port number to be used for SCP service.
         /// </summary>
-        [JsonProperty(PropertyName = "port")]
+        [ConfigurationKeyName("port")]
         public int Port { get; set; } = 104;
 
         /// <summary>
         /// Gets or sets maximum number of simultaneous DICOM associations for the SCP service.
         /// </summary>
-        [JsonProperty(PropertyName = "maximumNumberOfAssociations")]
+        [ConfigurationKeyName("maximumNumberOfAssociations")]
         public int MaximumNumberOfAssociations { get; set; } = DefaultMaximumNumberOfAssociations;
 
         /// <summary>
         /// Gets or sets wheather or not to enable verification (C-ECHO) service
         /// </summary>
-        [JsonProperty(PropertyName = "verification")]
+        [ConfigurationKeyName("verification")]
         public bool EnableVerification { get; set; } = true;
 
         /// <summary>
         /// Gets or sets whether or not associations shall be rejected if not defined in the <c>dicom>scp>sources</c> section.
         /// </summary>
-        [JsonProperty(PropertyName = "rejectUnknownSources")]
+        [ConfigurationKeyName("rejectUnknownSources")]
         public bool RejectUnknownSources { get; set; } = true;
 
         /// <summary>
         /// Gets or sets whether or not to write command and data datasets to the log.
         /// </summary>
-        [JsonProperty(PropertyName = "logDimseDatasets")]
+        [ConfigurationKeyName("logDimseDatasets")]
         public bool LogDimseDatasets { get; set; } = DefaultLogDimseDatasets;
 
         private static readonly List<string> VerificationServiceTransferSyntaxList = new List<string> {

--- a/src/Configuration/ScuConfiguration.cs
+++ b/src/Configuration/ScuConfiguration.cs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: © 2019-2021 NVIDIA Corporation
 // SPDX-License-Identifier: Apache License 2.0
 
-using Newtonsoft.Json;
+using Microsoft.Extensions.Configuration;
 
 namespace Monai.Deploy.InformaticsGateway.Configuration
 {
@@ -14,7 +14,7 @@ namespace Monai.Deploy.InformaticsGateway.Configuration
         /// <summary>
         /// Gets or sets the AE Title for SCU service.
         /// </summary>
-        [JsonProperty(PropertyName = "aeTitle")]
+        [ConfigurationKeyName("aeTitle")]
         public string AeTitle { get; set; } = "MONAISCU";
 
         /// <summary>
@@ -22,25 +22,25 @@ namespace Monai.Deploy.InformaticsGateway.Configuration
         /// The agent name is combine with <see cref="MessageBrokerConfigurationKeys.ExportRequestPrefix"/>
         /// for subscribing messages from the message broker service.
         /// </summary>
-        [JsonProperty(PropertyName = "agentName")]
+        [ConfigurationKeyName("agentName")]
         public string AgentName { get; set; } = "monaiscu";
 
         /// <summary>
         /// Gets or sets whether or not to write message to log for each P-Data-TF PDU sent or received.
         /// </summary>
-        [JsonProperty(PropertyName = "logDataPDUs")]
+        [ConfigurationKeyName("logDataPDUs")]
         public bool LogDataPdus { get; set; } = false;
 
         /// <summary>
         /// Gets or sets whether or not to write command and data datasets to the log.
         /// </summary>
-        [JsonProperty(PropertyName = "logDimseDatasets")]
+        [ConfigurationKeyName("logDimseDatasets")]
         public bool LogDimseDatasets { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the maximum number of simultaneous DICOM associations for the SCU service.
         /// </summary>
-        [JsonProperty(PropertyName = "maximumNumberOfAssociations")]
+        [ConfigurationKeyName("maximumNumberOfAssociations")]
         public int MaximumNumberOfAssociations { get; set; } = 8;
 
         public ScuConfiguration()

--- a/src/Configuration/StorageConfiguration.cs
+++ b/src/Configuration/StorageConfiguration.cs
@@ -49,7 +49,7 @@ namespace Monai.Deploy.InformaticsGateway.Configuration
         /// <summary>
         /// Gets or sets retry options relate to saving files to temporary storage, processing payloads and uploading payloads to the storage service.
         /// </summary>
-        [ConfigurationKeyName("reties")]
+        [ConfigurationKeyName("retries")]
         public RetryConfiguration Retries { get; set; } = new RetryConfiguration();
 
         /// <summary>


### PR DESCRIPTION
### Description

Fix typos in `ConfigurationKeyName` and use `ConfigurationKeyName` instead of `JsonProperty` for `IOptions` (de)serialization.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] All tests passed locally by running `./src/run-tests-in-docker.sh`.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] I have updated the changelog
