### PR TITLE
New options to configure database retries

### DIFF
--- a/src/Configuration/DatabaseConfiguration.cs
+++ b/src/Configuration/DatabaseConfiguration.cs
@@ -1,0 +1,29 @@
+﻿/*
+ * Copyright 2021-2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.Extensions.Configuration;
+
+namespace Monai.Deploy.InformaticsGateway.Configuration
+{
+    public class DatabaseConfiguration
+    {
+        /// <summary>
+        /// Gets or sets retry options relate to reading/writing to the database.
+        /// </summary>
+        [ConfigurationKeyName("retries")]
+        public RetryConfiguration Retries { get; set; } = new RetryConfiguration();
+    }
+}

--- a/src/Configuration/InformaticsGatewayConfiguration.cs
+++ b/src/Configuration/InformaticsGatewayConfiguration.cs
@@ -68,6 +68,12 @@ namespace Monai.Deploy.InformaticsGateway.Configuration
         [ConfigurationKeyName("messaging")]
         public MessageBrokerConfiguration Messaging { get; set; }
 
+        /// <summary>
+        /// Represents the <c>database</c> section of the configuration file.
+        /// </summary>
+        [ConfigurationKeyName("database")]
+        public DatabaseConfiguration Database { get; set; }
+
         public InformaticsGatewayConfiguration()
         {
             Dicom = new DicomConfiguration();
@@ -76,6 +82,7 @@ namespace Monai.Deploy.InformaticsGateway.Configuration
             Fhir = new FhirConfiguration();
             Export = new DataExportConfiguration();
             Messaging = new MessageBrokerConfiguration();
+            Database = new DatabaseConfiguration();
         }
     }
 }

--- a/src/InformaticsGateway/Services/Connectors/PayloadAssembler.cs
+++ b/src/InformaticsGateway/Services/Connectors/PayloadAssembler.cs
@@ -177,7 +177,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Connectors
                 payload.State = Payload.PayloadState.Upload;
                 var scope = _serviceScopeFactory.CreateScope();
                 var repository = scope.ServiceProvider.GetRequiredService<IInformaticsGatewayRepository<Payload>>();
-                await payload.UpdatePayload(_options.Value.Storage.Retries.RetryDelays, _logger, repository).ConfigureAwait(false);
+                await payload.UpdatePayload(_options.Value.Database.Retries.RetryDelays, _logger, repository).ConfigureAwait(false);
                 _workItems.Add(payload);
                 _logger.BucketReady(key, payload.Count);
             }
@@ -201,7 +201,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Connectors
                 var scope = _serviceScopeFactory.CreateScope();
                 var repository = scope.ServiceProvider.GetRequiredService<IInformaticsGatewayRepository<Payload>>();
                 var newPayload = new Payload(key, correationId, timeout);
-                await newPayload.AddPayaloadToDatabase(_options.Value.Storage.Retries.RetryDelays, _logger, repository).ConfigureAwait(false);
+                await newPayload.AddPayaloadToDatabase(_options.Value.Database.Retries.RetryDelays, _logger, repository).ConfigureAwait(false);
                 _logger.BucketCreated(key, timeout);
                 return newPayload;
             }));

--- a/src/InformaticsGateway/Services/Connectors/PayloadNotificationService.cs
+++ b/src/InformaticsGateway/Services/Connectors/PayloadNotificationService.cs
@@ -182,7 +182,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Connectors
 
                     var scope = _serviceScopeFactory.CreateScope();
                     var repository = scope.ServiceProvider.GetRequiredService<IInformaticsGatewayRepository<Payload>>();
-                    await payload.UpdatePayload(_options.Value.Storage.Retries.RetryDelays, _logger, repository).ConfigureAwait(false);
+                    await payload.UpdatePayload(_options.Value.Database.Retries.RetryDelays, _logger, repository).ConfigureAwait(false);
 
                     _publishQueue.Post(payload);
                     _logger.PayloadReadyToBePublished(payload.Id);
@@ -267,7 +267,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Connectors
 
                 var scope = _serviceScopeFactory.CreateScope();
                 var repository = scope.ServiceProvider.GetRequiredService<IInformaticsGatewayRepository<Payload>>();
-                await payload.DeletePayload(_options.Value.Storage.Retries.RetryDelays, _logger, repository).ConfigureAwait(false);
+                await payload.DeletePayload(_options.Value.Database.Retries.RetryDelays, _logger, repository).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -293,16 +293,16 @@ namespace Monai.Deploy.InformaticsGateway.Services.Connectors
 
             try
             {
-                if (payload.RetryCount > _options.Value.Storage.Retries.DelaysMilliseconds.Length)
+                if (payload.RetryCount > _options.Value.Database.Retries.DelaysMilliseconds.Length)
                 {
                     _logger.UploadFailureStopRetry(payload.Id);
-                    await payload.DeletePayload(_options.Value.Storage.Retries.RetryDelays, _logger, repository).ConfigureAwait(false);
+                    await payload.DeletePayload(_options.Value.Database.Retries.RetryDelays, _logger, repository).ConfigureAwait(false);
                     return PayloadAction.Deleted;
                 }
                 else
                 {
                     _logger.UploadFailureRetryLater(payload.Id, payload.State, payload.RetryCount);
-                    await payload.UpdatePayload(_options.Value.Storage.Retries.RetryDelays, _logger, repository).ConfigureAwait(false);
+                    await payload.UpdatePayload(_options.Value.Database.Retries.RetryDelays, _logger, repository).ConfigureAwait(false);
                     return PayloadAction.Updated;
                 }
             }

--- a/src/InformaticsGateway/Test/Services/Connectors/DataRetrievalServiceTest.cs
+++ b/src/InformaticsGateway/Test/Services/Connectors/DataRetrievalServiceTest.cs
@@ -117,10 +117,11 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
         [RetryFact(5, 250, DisplayName = "Constructor")]
         public void ConstructorTest()
         {
-            Assert.Throws<ArgumentNullException>(() => new DataRetrievalService(null, null));
-            Assert.Throws<ArgumentNullException>(() => new DataRetrievalService(_logger.Object, null));
+            Assert.Throws<ArgumentNullException>(() => new DataRetrievalService(null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new DataRetrievalService(_logger.Object, null, null));
+            Assert.Throws<ArgumentNullException>(() => new DataRetrievalService(_logger.Object, _serviceScopeFactory.Object, null));
 
-            _ = new DataRetrievalService(_logger.Object, _serviceScopeFactory.Object);
+            _ = new DataRetrievalService(_logger.Object, _serviceScopeFactory.Object, _options);
         }
 
         [RetryFact(5, 250, DisplayName = "Cancellation token shall stop the service")]
@@ -131,7 +132,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
             _storageInfoProvider.Setup(p => p.HasSpaceAvailableToRetrieve).Returns(true);
             _storageInfoProvider.Setup(p => p.AvailableFreeSpace).Returns(100);
 
-            var store = new DataRetrievalService(_logger.Object, _serviceScopeFactory.Object);
+            var store = new DataRetrievalService(_logger.Object, _serviceScopeFactory.Object, _options);
 
             await store.StartAsync(cancellationTokenSource.Token);
             Thread.Sleep(250);
@@ -152,7 +153,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
             _storageInfoProvider.Setup(p => p.HasSpaceAvailableToRetrieve).Returns(false);
             _storageInfoProvider.Setup(p => p.AvailableFreeSpace).Returns(100);
 
-            var store = new DataRetrievalService(_logger.Object, _serviceScopeFactory.Object);
+            var store = new DataRetrievalService(_logger.Object, _serviceScopeFactory.Object, _options);
 
             await store.StartAsync(cancellationTokenSource.Token);
             Thread.Sleep(250);
@@ -239,7 +240,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
                     cancellationTokenSource.CancelAfter(100);
                 })
                 .Returns(restoredFile);
-            var store = new DataRetrievalService(_logger.Object, _serviceScopeFactory.Object);
+            var store = new DataRetrievalService(_logger.Object, _serviceScopeFactory.Object, _options);
 
             await store.StartAsync(cancellationTokenSource.Token);
 
@@ -352,7 +353,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
             _fileStore.Setup(p => p.RestoreInferenceRequestFiles(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .Returns(new List<FileStoragePath>());
 
-            var store = new DataRetrievalService(_logger.Object, _serviceScopeFactory.Object);
+            var store = new DataRetrievalService(_logger.Object, _serviceScopeFactory.Object, _options);
 
             await store.StartAsync(cancellationTokenSource.Token);
 
@@ -503,7 +504,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
                     SopInstanceUid = dicomFile.Dataset.GetString(DicomTag.SOPInstanceUID),
                 });
 
-            var store = new DataRetrievalService(_logger.Object, _serviceScopeFactory.Object);
+            var store = new DataRetrievalService(_logger.Object, _serviceScopeFactory.Object, _options);
 
             await store.StartAsync(cancellationTokenSource.Token);
 
@@ -627,7 +628,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
                     SopInstanceUid = dicomFile.Dataset.GetString(DicomTag.SOPInstanceUID),
                 });
 
-            var store = new DataRetrievalService(_logger.Object, _serviceScopeFactory.Object);
+            var store = new DataRetrievalService(_logger.Object, _serviceScopeFactory.Object, _options);
 
             await store.StartAsync(cancellationTokenSource.Token);
 
@@ -762,7 +763,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
                     SopInstanceUid = dicomFile.Dataset.GetString(DicomTag.SOPInstanceUID),
                 });
 
-            var store = new DataRetrievalService(_logger.Object, _serviceScopeFactory.Object);
+            var store = new DataRetrievalService(_logger.Object, _serviceScopeFactory.Object, _options);
 
             await store.StartAsync(cancellationTokenSource.Token);
 
@@ -890,7 +891,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
                     ResourceId = resourceId,
                     ResourceType = resourceType,
                 });
-            var store = new DataRetrievalService(_logger.Object, _serviceScopeFactory.Object);
+            var store = new DataRetrievalService(_logger.Object, _serviceScopeFactory.Object, _options);
 
             await store.StartAsync(cancellationTokenSource.Token);
 

--- a/src/InformaticsGateway/Test/Services/Connectors/PayloadNotificationServiceTest.cs
+++ b/src/InformaticsGateway/Test/Services/Connectors/PayloadNotificationServiceTest.cs
@@ -91,7 +91,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
 
             _serviceScopeFactory.Setup(p => p.CreateScope()).Returns(scope.Object);
 
-            _options.Value.Storage.Retries.DelaysMilliseconds = new[] { 1 };
+            _options.Value.Database.Retries.DelaysMilliseconds = new[] { 1 };
             _options.Value.Storage.StorageServiceBucketName = "bucket";
             _logger.Setup(p => p.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
         }


### PR DESCRIPTION
### Description

Fixes #27.

Add new options to allow users to configure retries for any database connection errors.
Other Polly calls were already updated.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] I have updated the changelog
