### PR TITLE
Switch base image to 6.0-jammy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get clean \
  && apt-get update \
  && apt-get install -y --no-install-recommends \
-    libssl1.1 \
-    openssl \
     sqlite3 \
     curl \
    && rm -rf /var/lib/apt/lists

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-jammy as build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-focal as build
 
 # Install the tools
 RUN dotnet tool install --tool-path /tools dotnet-trace
@@ -26,7 +26,7 @@ RUN echo "Building MONAI Deploy Informatics Gateway..."
 RUN dotnet publish -c Release -o out --nologo src/InformaticsGateway/Monai.Deploy.InformaticsGateway.csproj
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-jammy
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-focal
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get clean \
@@ -34,7 +34,6 @@ RUN apt-get clean \
  && apt-get install -y --no-install-recommends \
     sqlite3 \
     curl \
-    tar \
    && rm -rf /var/lib/apt/lists
 
 WORKDIR /opt/monai/ig

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get clean \
  && apt-get install -y --no-install-recommends \
     sqlite3 \
     curl \
+    tar \
    && rm -rf /var/lib/apt/lists
 
 WORKDIR /opt/monai/ig

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-focal as build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-jammy as build
 
 # Install the tools
 RUN dotnet tool install --tool-path /tools dotnet-trace
@@ -26,7 +26,7 @@ RUN echo "Building MONAI Deploy Informatics Gateway..."
 RUN dotnet publish -c Release -o out --nologo src/InformaticsGateway/Monai.Deploy.InformaticsGateway.csproj
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-focal
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-jammy
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get clean \
@@ -34,7 +34,7 @@ RUN apt-get clean \
  && apt-get install -y --no-install-recommends \
     sqlite3 \
     curl \
-   && rm -rf /var/lib/apt/lists
+    && rm -rf /var/lib/apt/lists
 
 WORKDIR /opt/monai/ig
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-focal as build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-jammy as build
 
 # Install the tools
 RUN dotnet tool install --tool-path /tools dotnet-trace
@@ -26,7 +26,7 @@ RUN echo "Building MONAI Deploy Informatics Gateway..."
 RUN dotnet publish -c Release -o out --nologo src/InformaticsGateway/Monai.Deploy.InformaticsGateway.csproj
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-focal
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-jammy
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get clean \


### PR DESCRIPTION
### Description

Upgrade base image to use `6.0-jammy` (ubuntu 22.04) based.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] I have updated the changelog
