### PR TITLE
Update fo-dicom to 5.0.3

### DIFF
--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -1866,7 +1866,7 @@
   - :who: mocsharp
     :why: Microsoft Public License (https://github.com/fo-dicom/fo-dicom/raw/development/License.txt)
     :versions:
-    - 5.0.2
+    - 5.0.3
     :when: 2022-08-16 23:07:29.574869349 Z
 - - :approve
   - runtime.any.System.Collections
@@ -2400,4 +2400,3 @@
     :versions:
     - 4.0.1
     :when: 2022-08-16 23:10:21.184627612 Z
-    

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -805,6 +805,13 @@
     - 17.3.1
     :when: 2022-09-01 23:06:18.619013325 Z
 - - :approve
+  - Microsoft.Toolkit.HighPerformance
+  - :who: mocsharp
+    :why: MIT (https://github.com/CommunityToolkit/WindowsCommunityToolkit/raw/main/License.md)
+    :versions:
+    - 7.1.2
+    :when: 2022-09-20 00:42:18.619013325 Z
+- - :approve
   - Microsoft.Win32.Primitives
   - :who: mocsharp
     :why: MICROSOFT .NET LIBRARY License ( http://go.microsoft.com/fwlink/?LinkId=329770)

--- a/docker-compose/docker-compose.dev.yml
+++ b/docker-compose/docker-compose.dev.yml
@@ -39,7 +39,8 @@ services:
       - ./.run/minio/data:/data
       - ./.run/minio/config:/root/.minio
     ports:
-      - "9000:9000"
+      - 9000:9000
+      - 9001:9001
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin

--- a/docs/compliance/third-party-licenses.md
+++ b/docs/compliance/third-party-licenses.md
@@ -26864,14 +26864,14 @@ SOFTWARE.
 
 
 <details>
-<summary>fo-dicom 5.0.2</summary>
+<summary>fo-dicom 5.0.3</summary>
 
 ## fo-dicom
 
-- Version: 5.0.2
+- Version: 5.0.3
 - Authors: fo-dicom contributors
 - Project URL: https://github.com/fo-dicom/fo-dicom
-- Source: [NuGet](https://www.nuget.org/packages/fo-dicom/5.0.2)
+- Source: [NuGet](https://www.nuget.org/packages/fo-dicom/5.0.3)
 - License: [Microsoft Public License](https://github.com/fo-dicom/fo-dicom/raw/development/License.txt)
 
 

--- a/docs/compliance/third-party-licenses.md
+++ b/docs/compliance/third-party-licenses.md
@@ -6046,6 +6046,41 @@ SOFTWARE.
 
 
 <details>
+<summary>Microsoft.Toolkit.HighPerformance 7.1.2</summary>
+
+## Microsoft.Toolkit.HighPerformance
+
+- Version: 7.1.2
+- Authors: Microsoft
+- Owners: Microsoft.Toolkit,dotnetfoundation
+- Project URL: https://dot.net/
+- Source: [NuGet](https://www.nuget.org/packages/Microsoft.Toolkit.HighPerformance/7.1.2)
+- License: [MIT]( https://github.com/CommunityToolkit/WindowsCommunityToolkit/raw/main/License.md)
+
+
+```
+# Windows Community Toolkit
+
+Copyright © .NET Foundation and Contributors
+
+All rights reserved.
+
+## MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”),
+to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+```
+
+</details>
+<details>
 <summary>Microsoft.Win32.Primitives 4.3.0</summary>
 
 ## Microsoft.Win32.Primitives

--- a/src/Common/Monai.Deploy.InformaticsGateway.Common.csproj
+++ b/src/Common/Monai.Deploy.InformaticsGateway.Common.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
-    <PackageReference Include="fo-dicom" Version="5.0.2" />
+    <PackageReference Include="fo-dicom" Version="5.0.3" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.10.3">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/Configuration/DicomConfiguration.cs
+++ b/src/Configuration/DicomConfiguration.cs
@@ -41,5 +41,11 @@ namespace Monai.Deploy.InformaticsGateway.Configuration
         /// </summary>
         [ConfigurationKeyName("writeDicomJson")]
         public DicomJsonOptions WriteDicomJson { get; set; } = DicomJsonOptions.IgnoreOthers;
+
+        /// <summary>
+        /// Gets or sets whether to automatically validate the DICOM values when serializing to JSON.
+        /// Defaults to False.
+        /// </summary>
+        public bool ValidateDicomOnSerialization { get; set; } = false;
     }
 }

--- a/src/DicomWebClient/CLI/Monai.Deploy.InformaticsGateway.DicomWeb.Client.CLI.csproj
+++ b/src/DicomWebClient/CLI/Monai.Deploy.InformaticsGateway.DicomWeb.Client.CLI.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="ConsoleAppFramework" Version="4.2.2" />
-    <PackageReference Include="fo-dicom" Version="5.0.2" />
+    <PackageReference Include="fo-dicom" Version="5.0.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/src/DicomWebClient/Monai.Deploy.InformaticsGateway.DicomWeb.Client.csproj
+++ b/src/DicomWebClient/Monai.Deploy.InformaticsGateway.DicomWeb.Client.csproj
@@ -43,7 +43,7 @@
 
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
-    <PackageReference Include="fo-dicom" Version="5.0.2" />
+    <PackageReference Include="fo-dicom" Version="5.0.3" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.10.3">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/InformaticsGateway/Common/DicomExtensions.cs
+++ b/src/InformaticsGateway/Common/DicomExtensions.cs
@@ -52,12 +52,15 @@ namespace Monai.Deploy.InformaticsGateway.Common
             return dicomTransferSyntaxes.ToArray();
         }
 
-        public static string ToJson(this DicomFile dicomFile, DicomJsonOptions dicomJsonOptions)
+        public static string ToJson(this DicomFile dicomFile, DicomJsonOptions dicomJsonOptions, bool validateDicom)
         {
             Guard.Against.Null(dicomFile, nameof(dicomFile));
 
             var options = new JsonSerializerOptions();
-            options.Converters.Add(new DicomJsonConverter(writeTagsAsKeywords: false, autoValidate: true));
+            options.Converters.Add(new DicomJsonConverter(
+                writeTagsAsKeywords: false,
+                autoValidate: validateDicom,
+                numberSerializationMode: validateDicom ? NumberSerializationMode.AsNumber : NumberSerializationMode.PreferablyAsNumber));
             options.WriteIndented = false;
 
             if (dicomJsonOptions == DicomJsonOptions.Complete)

--- a/src/InformaticsGateway/Monai.Deploy.InformaticsGateway.csproj
+++ b/src/InformaticsGateway/Monai.Deploy.InformaticsGateway.csproj
@@ -34,7 +34,7 @@
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
     <PackageReference Include="DotNext.Threading" Version="4.7.1" />
-    <PackageReference Include="fo-dicom" Version="5.0.2" />
+    <PackageReference Include="fo-dicom" Version="5.0.3" />
     <PackageReference Include="Karambolo.Extensions.Logging.File" Version="3.3.1" />
     <PackageReference Include="HL7-dotnetcore" Version="2.29.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.10.3">

--- a/src/InformaticsGateway/Services/Connectors/DataRetrievalService.cs
+++ b/src/InformaticsGateway/Services/Connectors/DataRetrievalService.cs
@@ -509,7 +509,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Connectors
                     }
 
                     var dicomFileStorageMetadata = SaveFile(transactionId, file, uids);
-                    await dicomFileStorageMetadata.SetDataStreams(file, file.ToJson(_options.Value.Dicom.WriteDicomJson)).ConfigureAwait(false);
+                    await dicomFileStorageMetadata.SetDataStreams(file, file.ToJson(_options.Value.Dicom.WriteDicomJson, _options.Value.Dicom.ValidateDicomOnSerialization)).ConfigureAwait(false);
                     retrievedInstance.Add(uids.Identifier, dicomFileStorageMetadata);
                     count++;
                 }
@@ -539,7 +539,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Connectors
                 }
 
                 var dicomFileStorageMetadata = SaveFile(transactionId, file, uids);
-                await dicomFileStorageMetadata.SetDataStreams(file, file.ToJson(_options.Value.Dicom.WriteDicomJson)).ConfigureAwait(false);
+                await dicomFileStorageMetadata.SetDataStreams(file, file.ToJson(_options.Value.Dicom.WriteDicomJson, _options.Value.Dicom.ValidateDicomOnSerialization)).ConfigureAwait(false);
                 retrievedInstance.Add(uids.Identifier, dicomFileStorageMetadata);
             }
         }

--- a/src/InformaticsGateway/Services/DicomWeb/IStreamsWriter.cs
+++ b/src/InformaticsGateway/Services/DicomWeb/IStreamsWriter.cs
@@ -165,7 +165,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.DicomWeb
                 dicomInfo.SetWorkflows(workflowName);
             }
 
-            await dicomInfo.SetDataStreams(dicomFile, dicomFile.ToJson(_configuration.Value.Dicom.WriteDicomJson)).ConfigureAwait(false);
+            await dicomInfo.SetDataStreams(dicomFile, dicomFile.ToJson(_configuration.Value.Dicom.WriteDicomJson, _configuration.Value.Dicom.ValidateDicomOnSerialization)).ConfigureAwait(false);
             _uploadQueue.Queue(dicomInfo);
 
             // for DICOMweb, use correlation ID as the grouping key

--- a/src/InformaticsGateway/Services/Scp/ApplicationEntityManager.cs
+++ b/src/InformaticsGateway/Services/Scp/ApplicationEntityManager.cs
@@ -143,7 +143,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Scp
         {
             var scope = _serviceScopeFactory.CreateScope();
             var handler = scope.ServiceProvider.GetService<IApplicationEntityHandler>() ?? throw new ServiceNotFoundException(nameof(IApplicationEntityHandler));
-            handler.Configure(entity, Configuration.Value.Dicom.WriteDicomJson);
+            handler.Configure(entity, Configuration.Value.Dicom.WriteDicomJson, Configuration.Value.Dicom.ValidateDicomOnSerialization);
 
             if (!_aeTitles.TryAdd(entity.AeTitle, handler))
             {

--- a/src/InformaticsGateway/Services/Scp/IApplicationEntityHandler.cs
+++ b/src/InformaticsGateway/Services/Scp/IApplicationEntityHandler.cs
@@ -25,7 +25,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Scp
 {
     internal interface IApplicationEntityHandler
     {
-        void Configure(MonaiApplicationEntity monaiApplicationEntity, DicomJsonOptions dicomJsonOptions);
+        void Configure(MonaiApplicationEntity monaiApplicationEntity, DicomJsonOptions dicomJsonOptions, bool validateDicomValuesOnJsonSerialization);
 
         Task HandleInstanceAsync(DicomCStoreRequest request, string calledAeTitle, string callingAeTitle, Guid associationId, StudySerieSopUids uids);
     }

--- a/src/InformaticsGateway/Services/Scp/ScpServiceInternal.cs
+++ b/src/InformaticsGateway/Services/Scp/ScpServiceInternal.cs
@@ -21,8 +21,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using FellowOakDicom;
-using FellowOakDicom.Imaging.Codec;
-using FellowOakDicom.Log;
 using FellowOakDicom.Network;
 using Monai.Deploy.InformaticsGateway.Api;
 using Monai.Deploy.InformaticsGateway.Common;
@@ -44,8 +42,8 @@ namespace Monai.Deploy.InformaticsGateway.Services.Scp
         private IDisposable _loggerScope;
         private Guid _associationId;
 
-        public ScpServiceInternal(INetworkStream stream, Encoding fallbackEncoding, FellowOakDicom.Log.ILogger log, ILogManager logManager, INetworkManager network, ITranscoderManager transcoder)
-                : base(stream, fallbackEncoding, log, logManager, network, transcoder)
+        public ScpServiceInternal(INetworkStream stream, Encoding fallbackEncoding, FellowOakDicom.Log.ILogger log, DicomServiceDependencies dicomServiceDependencies)
+                : base(stream, fallbackEncoding, log, dicomServiceDependencies)
         {
         }
 

--- a/src/InformaticsGateway/Test/Services/Scp/ApplicationEntityHandlerTest.cs
+++ b/src/InformaticsGateway/Test/Services/Scp/ApplicationEntityHandlerTest.cs
@@ -104,7 +104,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Scp
             };
 
             var handler = new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object);
-            handler.Configure(aet, Configuration.DicomJsonOptions.Complete);
+            handler.Configure(aet, Configuration.DicomJsonOptions.Complete, true);
 
             var request = GenerateRequest();
             var dicomToolkit = new DicomToolkit();
@@ -128,7 +128,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Scp
             };
 
             var handler = new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object);
-            handler.Configure(aet, Configuration.DicomJsonOptions.Complete);
+            handler.Configure(aet, Configuration.DicomJsonOptions.Complete, true);
 
             var request = GenerateRequest();
             var dicomToolkit = new DicomToolkit();
@@ -151,7 +151,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Scp
             };
 
             var handler = new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object);
-            handler.Configure(aet, Configuration.DicomJsonOptions.Complete);
+            handler.Configure(aet, Configuration.DicomJsonOptions.Complete, true);
 
             var request = GenerateRequest();
             var dicomToolkit = new DicomToolkit();

--- a/src/InformaticsGateway/Test/Shared/DicomScpFixture.cs
+++ b/src/InformaticsGateway/Test/Shared/DicomScpFixture.cs
@@ -19,8 +19,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using FellowOakDicom;
-using FellowOakDicom.Imaging.Codec;
-using FellowOakDicom.Log;
 using FellowOakDicom.Network;
 using Microsoft.Extensions.Logging;
 
@@ -78,8 +76,8 @@ namespace Monai.Deploy.InformaticsGateway.SharedTest
 
     public class CStoreScp : DicomService, IDicomServiceProvider, IDicomCStoreProvider, IDicomCEchoProvider
     {
-        public CStoreScp(INetworkStream stream, Encoding fallbackEncoding, FellowOakDicom.Log.ILogger log, ILogManager logManager, INetworkManager network, ITranscoderManager transcoder)
-                : base(stream, fallbackEncoding, log, logManager, network, transcoder)
+        public CStoreScp(INetworkStream stream, Encoding fallbackEncoding, FellowOakDicom.Log.ILogger log, DicomServiceDependencies dicomServiceDependencies)
+                : base(stream, fallbackEncoding, log, dicomServiceDependencies)
         {
         }
 

--- a/tests/Integration.Test/Drivers/DicomScp.cs
+++ b/tests/Integration.Test/Drivers/DicomScp.cs
@@ -16,7 +16,6 @@
 
 using System.Text;
 using FellowOakDicom;
-using FellowOakDicom.Imaging.Codec;
 using FellowOakDicom.Log;
 using FellowOakDicom.Network;
 using Monai.Deploy.InformaticsGateway.Integration.Test.Common;
@@ -36,8 +35,8 @@ namespace Monai.Deploy.InformaticsGateway.Integration.Test.Drivers
         private static readonly Object SyncLock = new Object();
         internal static readonly string PayloadsRoot = "./payloads";
 
-        public CStoreScp(INetworkStream stream, Encoding fallbackEncoding, ILogger log, ILogManager logManager, INetworkManager network, ITranscoderManager transcoder)
-            : base(stream, fallbackEncoding, log, logManager, network, transcoder)
+        public CStoreScp(INetworkStream stream, Encoding fallbackEncoding, ILogger log, DicomServiceDependencies dicomServiceDependencies)
+            : base(stream, fallbackEncoding, log, dicomServiceDependencies)
         {
         }
 

--- a/tests/Integration.Test/Monai.Deploy.InformaticsGateway.Integration.Test.csproj
+++ b/tests/Integration.Test/Monai.Deploy.InformaticsGateway.Integration.Test.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="fo-dicom" Version="5.0.2" />
+    <PackageReference Include="fo-dicom" Version="5.0.3" />
     <PackageReference Include="HL7-dotnetcore" Version="2.29.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.8" />


### PR DESCRIPTION
### Description

- Upgrade fo-dicom to 5.0.3 and handle breaking changes in `DicomService` and `DicomClient`.
- New configuration to allow users to configure whether to auto-validate DICOM values on JSON serialization with default to false.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] I have updated the changelog
