### PR TITLE
Ability to switch temporary storage to use either memory or disk

### DIFF
--- a/src/Api/Storage/Payload.cs
+++ b/src/Api/Storage/Payload.cs
@@ -66,6 +66,8 @@ namespace Monai.Deploy.InformaticsGateway.Api.Storage
 
         public bool HasTimedOut { get => ElapsedTime().TotalSeconds >= Timeout; }
 
+        public TimeSpan Elapsed { get { return DateTime.UtcNow.Subtract(DateTimeCreated); } }
+
         public string CallingAeTitle { get => Files.OfType<DicomFileStorageMetadata>().Select(p => p.CallingAeTitle).FirstOrDefault(); }
 
         public string CalledAeTitle { get => Files.OfType<DicomFileStorageMetadata>().Select(p => p.CalledAeTitle).FirstOrDefault(); }

--- a/src/Configuration/StorageConfiguration.cs
+++ b/src/Configuration/StorageConfiguration.cs
@@ -26,7 +26,7 @@ namespace Monai.Deploy.InformaticsGateway.Configuration
         /// Gets or sets whether to store temporary data in <c>Memory</c> or on <c>Disk</c>.
         /// Defaults to <c>Memory</c>.
         /// </summary>
-        [ConfigurationKeyName("bufferRootPath")]
+        [ConfigurationKeyName("tempStorageLocation")]
         public TemporaryDataStorageLocation TemporaryDataStorage { get; set; } = TemporaryDataStorageLocation.Memory;
 
         /// <summary>

--- a/src/Configuration/StorageConfiguration.cs
+++ b/src/Configuration/StorageConfiguration.cs
@@ -23,11 +23,26 @@ namespace Monai.Deploy.InformaticsGateway.Configuration
     public class StorageConfiguration : StorageServiceConfiguration
     {
         /// <summary>
+        /// Gets or sets whether to store temporary data in <c>Memory</c> or on <c>Disk</c>.
+        /// Defaults to <c>Memory</c>.
+        /// </summary>
+        [ConfigurationKeyName("bufferRootPath")]
+        public TemporaryDataStorageLocation TemporaryDataStorage { get; set; } = TemporaryDataStorageLocation.Memory;
+
+        /// <summary>
         /// Gets or sets the path used for buffering incoming data.
         /// Defaults to <c>./temp</c>.
         /// </summary>
         [ConfigurationKeyName("bufferRootPath")]
         public string BufferStorageRootPath { get; set; } = "./temp";
+
+        /// <summary>
+        /// Gets or sets the number of bytes buffered for reads and writes to the temporary file.
+        /// Defaults to <c>128000</c>.
+        /// </summary>
+        [ConfigurationKeyName("bufferSize")]
+        public int BufferSize { get; set; } = 128000;
+
 
         /// <summary>
         /// Gets or set the maximum memory buffer size in bytes with default to 30MiB.

--- a/src/Configuration/TemporaryDataStorageLocation.cs
+++ b/src/Configuration/TemporaryDataStorageLocation.cs
@@ -1,0 +1,24 @@
+﻿/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Monai.Deploy.InformaticsGateway.Configuration
+{
+    public enum TemporaryDataStorageLocation
+    {
+        Memory,
+        Disk
+    }
+}

--- a/src/Configuration/Test/ConfigurationValidatorTest.cs
+++ b/src/Configuration/Test/ConfigurationValidatorTest.cs
@@ -15,6 +15,8 @@
  */
 
 using System;
+using System.IO;
+using System.IO.Abstractions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Monai.Deploy.InformaticsGateway.SharedTest;
@@ -26,17 +28,19 @@ namespace Monai.Deploy.InformaticsGateway.Configuration.Test
     public class ConfigurationValidatorTest
     {
         private readonly Mock<ILogger<ConfigurationValidator>> _logger;
+        private readonly Mock<IFileSystem> _fileSystem;
 
         public ConfigurationValidatorTest()
         {
             _logger = new Mock<ILogger<ConfigurationValidator>>();
+            _fileSystem = new Mock<IFileSystem>();
         }
 
         [Fact(DisplayName = "ConfigurationValidator test with all valid settings")]
         public void AllValid()
         {
             var config = MockValidConfiguration();
-            var valid = new ConfigurationValidator(_logger.Object).Validate("", config);
+            var valid = new ConfigurationValidator(_logger.Object, _fileSystem.Object).Validate("", config);
             Assert.True(valid == ValidateOptionsResult.Success);
         }
 
@@ -46,7 +50,7 @@ namespace Monai.Deploy.InformaticsGateway.Configuration.Test
             var config = MockValidConfiguration();
             config.Dicom.Scp.Port = Int32.MaxValue;
 
-            var valid = new ConfigurationValidator(_logger.Object).Validate("", config);
+            var valid = new ConfigurationValidator(_logger.Object, _fileSystem.Object).Validate("", config);
 
             var validationMessage = $"Invalid port number '{Int32.MaxValue}' specified for InformaticsGateway>dicom>scp>port.";
             Assert.Equal(validationMessage, valid.FailureMessage);
@@ -59,7 +63,7 @@ namespace Monai.Deploy.InformaticsGateway.Configuration.Test
             var config = MockValidConfiguration();
             config.Dicom.Scp.MaximumNumberOfAssociations = 0;
 
-            var valid = new ConfigurationValidator(_logger.Object).Validate("", config);
+            var valid = new ConfigurationValidator(_logger.Object, _fileSystem.Object).Validate("", config);
 
             var validationMessage = $"Value of InformaticsGateway>dicom>scp>max-associations must be between {1} and {1000}.";
             Assert.Equal(validationMessage, valid.FailureMessage);
@@ -72,7 +76,7 @@ namespace Monai.Deploy.InformaticsGateway.Configuration.Test
             var config = MockValidConfiguration();
             config.Storage.Watermark = 1000;
 
-            var valid = new ConfigurationValidator(_logger.Object).Validate("", config);
+            var valid = new ConfigurationValidator(_logger.Object, _fileSystem.Object).Validate("", config);
 
             var validationMessage = "Value of InformaticsGateway>storage>watermark must be between 1 and 100.";
             Assert.Equal(validationMessage, valid.FailureMessage);
@@ -85,7 +89,7 @@ namespace Monai.Deploy.InformaticsGateway.Configuration.Test
             var config = MockValidConfiguration();
             config.Storage.ReserveSpaceGB = 9999;
 
-            var valid = new ConfigurationValidator(_logger.Object).Validate("", config);
+            var valid = new ConfigurationValidator(_logger.Object, _fileSystem.Object).Validate("", config);
 
             var validationMessage = "Value of InformaticsGateway>storage>reserveSpaceGB must be between 1 and 999.";
             Assert.Equal(validationMessage, valid.FailureMessage);
@@ -98,7 +102,7 @@ namespace Monai.Deploy.InformaticsGateway.Configuration.Test
             var config = MockValidConfiguration();
             config.Storage.TemporaryStorageBucket = " ";
 
-            var valid = new ConfigurationValidator(_logger.Object).Validate("", config);
+            var valid = new ConfigurationValidator(_logger.Object, _fileSystem.Object).Validate("", config);
 
             var validationMessages = new[] { "Value for InformaticsGateway>storage>temporaryBucketName is required.", "Value for InformaticsGateway>storage>temporaryBucketName does not conform to Amazon S3 bucket naming requirements." };
             Assert.Equal(string.Join(Environment.NewLine, validationMessages), valid.FailureMessage);
@@ -114,9 +118,29 @@ namespace Monai.Deploy.InformaticsGateway.Configuration.Test
             var config = MockValidConfiguration();
             config.Storage.StorageServiceBucketName = "";
 
-            var valid = new ConfigurationValidator(_logger.Object).Validate("", config);
+            var valid = new ConfigurationValidator(_logger.Object, _fileSystem.Object).Validate("", config);
 
             var validationMessages = new[] { "Value for InformaticsGateway>storage>bucketName is required.", "Value for InformaticsGateway>storage>bucketName does not conform to Amazon S3 bucket naming requirements." };
+            Assert.Equal(string.Join(Environment.NewLine, validationMessages), valid.FailureMessage);
+            foreach (var message in validationMessages)
+            {
+                _logger.VerifyLogging(message, LogLevel.Error, Times.Once());
+            }
+        }
+
+        [Fact(DisplayName = "ConfigurationValidator test with inaccessible directory")]
+        public void StorageWithInaccessbleDirectory()
+        {
+            _fileSystem.Setup(p => p.Directory.Exists(It.IsAny<string>())).Returns(true);
+            _fileSystem.Setup(p => p.File.Create(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<FileOptions>())).Throws(new UnauthorizedAccessException("error"));
+
+            var config = MockValidConfiguration();
+            config.Storage.TemporaryDataStorage = TemporaryDataStorageLocation.Disk;
+            config.Storage.BufferStorageRootPath = "/blabla";
+
+            var valid = new ConfigurationValidator(_logger.Object, _fileSystem.Object).Validate("", config);
+
+            var validationMessages = new[] { $"Directory `/blabla` specified in `InformaticsGateway>storage>bufferRootPath` is not accessible: error." };
             Assert.Equal(string.Join(Environment.NewLine, validationMessages), valid.FailureMessage);
             foreach (var message in validationMessages)
             {

--- a/src/Database/PayloadConfiguration.cs
+++ b/src/Database/PayloadConfiguration.cs
@@ -57,6 +57,7 @@ namespace Monai.Deploy.InformaticsGateway.Database
             builder.Ignore(j => j.CalledAeTitle);
             builder.Ignore(j => j.CallingAeTitle);
             builder.Ignore(j => j.HasTimedOut);
+            builder.Ignore(j => j.Elapsed);
             builder.Ignore(j => j.Count);
         }
     }

--- a/src/InformaticsGateway/Common/FileStorageMetadataExtensions.cs
+++ b/src/InformaticsGateway/Common/FileStorageMetadataExtensions.cs
@@ -14,41 +14,92 @@
  * limitations under the License.
  */
 
-using System.IO;
+using System.IO.Abstractions;
 using System.Text;
 using System.Threading.Tasks;
 using Ardalis.GuardClauses;
 using FellowOakDicom;
 using Monai.Deploy.InformaticsGateway.Api.Storage;
+using Monai.Deploy.InformaticsGateway.Configuration;
 
 namespace Monai.Deploy.InformaticsGateway.Common
 {
     internal static class FileStorageMetadataExtensions
     {
-        public static async Task SetDataStreams(this DicomFileStorageMetadata dicomFileStorageMetadata, DicomFile dicomFile, string dicomJson)
+        public static async Task SetDataStreams(
+            this DicomFileStorageMetadata dicomFileStorageMetadata,
+            DicomFile dicomFile,
+            string dicomJson,
+            TemporaryDataStorageLocation storageLocation,
+            IFileSystem fileSystem = null,
+            string temporaryStoragePath = "")
         {
             Guard.Against.Null(dicomFile, nameof(dicomFile));
             Guard.Against.Null(dicomJson, nameof(dicomJson)); // allow empty here
 
-            dicomFileStorageMetadata.File.Data = new MemoryStream();
-            await dicomFile.SaveAsync(dicomFileStorageMetadata.File.Data).ConfigureAwait(false);
-            dicomFileStorageMetadata.File.Data.Seek(0, SeekOrigin.Begin);
+            switch (storageLocation)
+            {
+                case TemporaryDataStorageLocation.Disk:
+                    Guard.Against.Null(fileSystem, nameof(fileSystem));
+                    Guard.Against.NullOrWhiteSpace(temporaryStoragePath, nameof(temporaryStoragePath));
 
-            SetTextStream(dicomFileStorageMetadata.JsonFile, dicomJson);
+                    var tempFile = fileSystem.Path.Combine(temporaryStoragePath, $@"{System.DateTime.UtcNow.Ticks}.tmp");
+                    dicomFileStorageMetadata.File.Data = fileSystem.File.Create(tempFile);
+                    break;
+                default:
+                    dicomFileStorageMetadata.File.Data = new System.IO.MemoryStream();
+                    break;
+            }
+
+            await dicomFile.SaveAsync(dicomFileStorageMetadata.File.Data).ConfigureAwait(false);
+            dicomFileStorageMetadata.File.Data.Seek(0, System.IO.SeekOrigin.Begin);
+
+            await SetTextStream(dicomFileStorageMetadata.JsonFile, dicomJson, storageLocation, fileSystem, temporaryStoragePath);
         }
 
-        public static void SetDataStream(this FhirFileStorageMetadata fhirFileStorageMetadata, string json)
-            => SetTextStream(fhirFileStorageMetadata.File, json);
+        public static async Task SetDataStream(
+            this FhirFileStorageMetadata fhirFileStorageMetadata,
+            string json,
+            TemporaryDataStorageLocation storageLocation,
+            IFileSystem fileSystem = null,
+            string temporaryStoragePath = "")
+            => await SetTextStream(fhirFileStorageMetadata.File, json, storageLocation, fileSystem, temporaryStoragePath);
 
-        public static void SetDataStream(this Hl7FileStorageMetadata hl7FileStorageMetadata, string message)
-            => SetTextStream(hl7FileStorageMetadata.File, message);
+        public static async Task SetDataStream(
+            this Hl7FileStorageMetadata hl7FileStorageMetadata,
+             string message,
+             TemporaryDataStorageLocation storageLocation,
+            IFileSystem fileSystem = null,
+             string temporaryStoragePath = "")
+            => await SetTextStream(hl7FileStorageMetadata.File, message, storageLocation, fileSystem, temporaryStoragePath);
 
-        private static void SetTextStream(StorageObjectMetadata storageObjectMetadata, string message)
+        private static async Task SetTextStream(
+            StorageObjectMetadata storageObjectMetadata,
+            string message,
+            TemporaryDataStorageLocation storageLocation,
+            IFileSystem fileSystem = null,
+            string temporaryStoragePath = "")
         {
             Guard.Against.Null(message, nameof(message)); // allow empty here
 
-            storageObjectMetadata.Data = new MemoryStream(Encoding.UTF8.GetBytes(message));
-            storageObjectMetadata.Data.Seek(0, SeekOrigin.Begin);
+            switch (storageLocation)
+            {
+                case TemporaryDataStorageLocation.Disk:
+                    Guard.Against.Null(fileSystem, nameof(fileSystem));
+                    Guard.Against.NullOrWhiteSpace(temporaryStoragePath, nameof(temporaryStoragePath));
+
+                    var tempFile = fileSystem.Path.Combine(temporaryStoragePath, $@"{System.DateTime.UtcNow.Ticks}.tmp");
+                    var stream = fileSystem.File.Create(tempFile);
+                    var data = Encoding.UTF8.GetBytes(message);
+                    await stream.WriteAsync(data, 0, data.Length);
+                    storageObjectMetadata.Data = stream;
+                    break;
+                default:
+                    storageObjectMetadata.Data = new System.IO.MemoryStream(Encoding.UTF8.GetBytes(message));
+                    break;
+            }
+
+            storageObjectMetadata.Data.Seek(0, System.IO.SeekOrigin.Begin);
         }
     }
 }

--- a/src/InformaticsGateway/Logging/Log.700.PayloadService.cs
+++ b/src/InformaticsGateway/Logging/Log.700.PayloadService.cs
@@ -53,8 +53,8 @@ namespace Monai.Deploy.InformaticsGateway.Logging
         [LoggerMessage(EventId = 711, Level = LogLevel.Information, Message = "Publishing workflow request message ID={messageId}...")]
         public static partial void PublishingWorkflowRequest(this ILogger logger, string messageId);
 
-        [LoggerMessage(EventId = 712, Level = LogLevel.Information, Message = "Workflow request published to {queue}, message ID={messageId}.")]
-        public static partial void WorkflowRequestPublished(this ILogger logger, string queue, string messageId);
+        [LoggerMessage(EventId = 712, Level = LogLevel.Information, Message = "Workflow request published to {queue}, message ID={messageId}. Payload took {payloadElapsedTime} to complete.")]
+        public static partial void WorkflowRequestPublished(this ILogger logger, string queue, string messageId, TimeSpan payloadElapsedTime);
 
         [LoggerMessage(EventId = 713, Level = LogLevel.Information, Message = "Restoring payloads from database.")]
         public static partial void StartupRestoreFromDatabase(this ILogger logger);

--- a/src/InformaticsGateway/Services/Connectors/PayloadNotificationActionHandler.cs
+++ b/src/InformaticsGateway/Services/Connectors/PayloadNotificationActionHandler.cs
@@ -138,7 +138,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Connectors
                 _options.Value.Messaging.Topics.WorkflowRequest,
                 message.ToMessage()).ConfigureAwait(false);
 
-            _logger.WorkflowRequestPublished(_options.Value.Messaging.Topics.WorkflowRequest, message.MessageId);
+            _logger.WorkflowRequestPublished(_options.Value.Messaging.Topics.WorkflowRequest, message.MessageId, payload.Elapsed);
         }
 
         private async Task<PayloadAction> UpdatePayloadState(Payload payload)

--- a/src/InformaticsGateway/Services/DicomWeb/IStreamsWriter.cs
+++ b/src/InformaticsGateway/Services/DicomWeb/IStreamsWriter.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions;
 using System.Threading;
 using System.Threading.Tasks;
 using Ardalis.GuardClauses;
@@ -43,6 +44,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.DicomWeb
     internal class StreamsWriter : IStreamsWriter
     {
         private readonly ILogger<StreamsWriter> _logger;
+        private readonly IFileSystem _fileSystem;
         private readonly IObjectUploadQueue _uploadQueue;
         private readonly IDicomToolkit _dicomToolkit;
         private readonly IPayloadAssembler _payloadAssembler;
@@ -56,13 +58,15 @@ namespace Monai.Deploy.InformaticsGateway.Services.DicomWeb
             IDicomToolkit dicomToolkit,
             IPayloadAssembler payloadAssembler,
             IOptions<InformaticsGatewayConfiguration> configuration,
-            ILogger<StreamsWriter> logger)
+            ILogger<StreamsWriter> logger,
+            IFileSystem fileSystem)
         {
             _uploadQueue = fileStore ?? throw new ArgumentNullException(nameof(fileStore));
             _dicomToolkit = dicomToolkit ?? throw new ArgumentNullException(nameof(dicomToolkit));
             _payloadAssembler = payloadAssembler ?? throw new ArgumentNullException(nameof(payloadAssembler));
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
             _resultDicomDataset = new DicomDataset();
             _failureCount = 0;
             _storedCount = 0;
@@ -165,7 +169,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.DicomWeb
                 dicomInfo.SetWorkflows(workflowName);
             }
 
-            await dicomInfo.SetDataStreams(dicomFile, dicomFile.ToJson(_configuration.Value.Dicom.WriteDicomJson, _configuration.Value.Dicom.ValidateDicomOnSerialization)).ConfigureAwait(false);
+            await dicomInfo.SetDataStreams(dicomFile, dicomFile.ToJson(_configuration.Value.Dicom.WriteDicomJson, _configuration.Value.Dicom.ValidateDicomOnSerialization), _configuration.Value.Storage.TemporaryDataStorage, _fileSystem, _configuration.Value.Storage.BufferStorageRootPath).ConfigureAwait(false);
             _uploadQueue.Queue(dicomInfo);
 
             // for DICOMweb, use correlation ID as the grouping key

--- a/src/InformaticsGateway/Services/Fhir/FhirJsonReader.cs
+++ b/src/InformaticsGateway/Services/Fhir/FhirJsonReader.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.IO;
+using System.IO.Abstractions;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading;
@@ -23,9 +24,11 @@ using System.Threading.Tasks;
 using Ardalis.GuardClauses;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 using Monai.Deploy.InformaticsGateway.Api.Storage;
 using Monai.Deploy.InformaticsGateway.Common;
+using Monai.Deploy.InformaticsGateway.Configuration;
 using Monai.Deploy.InformaticsGateway.Logging;
 
 namespace Monai.Deploy.InformaticsGateway.Services.Fhir
@@ -33,10 +36,14 @@ namespace Monai.Deploy.InformaticsGateway.Services.Fhir
     internal class FhirJsonReader : IFHirRequestReader
     {
         private readonly ILogger<FhirJsonReader> _logger;
+        private readonly IOptions<InformaticsGatewayConfiguration> _options;
+        private readonly IFileSystem _fileSystem;
 
-        public FhirJsonReader(ILogger<FhirJsonReader> logger)
+        public FhirJsonReader(ILogger<FhirJsonReader> logger, IOptions<InformaticsGatewayConfiguration> options, IFileSystem fileSystem)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
         }
 
         public async Task<FhirStoreResult> GetContentAsync(HttpRequest request, string correlationId, string resourceType, MediaTypeHeaderValue mediaTypeHeaderValue, CancellationToken cancellationToken)
@@ -68,7 +75,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Fhir
             result.RawData = jsonDoc.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
 
             var fileMetadata = new FhirFileStorageMetadata(correlationId, result.InternalResourceType, resourceId, Api.Rest.FhirStorageFormat.Json);
-            fileMetadata.SetDataStream(result.RawData);
+            await fileMetadata.SetDataStream(result.RawData, _options.Value.Storage.TemporaryDataStorage, _fileSystem, _options.Value.Storage.BufferStorageRootPath);
 
             result.Metadata = fileMetadata;
             return result;

--- a/src/InformaticsGateway/Services/Fhir/FhirService.cs
+++ b/src/InformaticsGateway/Services/Fhir/FhirService.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.IO.Abstractions;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -41,6 +42,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Fhir
         private readonly ILogger<FhirService> _logger;
         private readonly IPayloadAssembler _payloadAssembler;
         private readonly IObjectUploadQueue _uploadQueue;
+        private readonly IFileSystem _fileSystem;
 
         public FhirService(IServiceScopeFactory serviceScopeFactory, IOptions<InformaticsGatewayConfiguration> configuration)
         {
@@ -51,6 +53,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Fhir
             _logger = scope.ServiceProvider.GetService<ILogger<FhirService>>() ?? throw new ServiceNotFoundException(nameof(ILogger<FhirService>));
             _payloadAssembler = scope.ServiceProvider.GetService<IPayloadAssembler>() ?? throw new ServiceNotFoundException(nameof(IPayloadAssembler));
             _uploadQueue = scope.ServiceProvider.GetService<IObjectUploadQueue>() ?? throw new ServiceNotFoundException(nameof(IObjectUploadQueue));
+            _fileSystem = scope.ServiceProvider.GetService<IFileSystem>() ?? throw new ServiceNotFoundException(nameof(IFileSystem));
         }
 
         public async Task<FhirStoreResult> StoreAsync(HttpRequest request, string correlationId, string resourceType, CancellationToken cancellationToken)
@@ -100,13 +103,13 @@ namespace Monai.Deploy.InformaticsGateway.Services.Fhir
             if (mediaTypeHeaderValue.MediaType.Equals(ContentTypes.ApplicationFhirJson, StringComparison.OrdinalIgnoreCase))
             {
                 var logger = scope.ServiceProvider.GetService<ILogger<FhirJsonReader>>() ?? throw new ServiceNotFoundException(nameof(ILogger<FhirJsonReader>));
-                return new FhirJsonReader(logger);
+                return new FhirJsonReader(logger, _configuration, _fileSystem);
             }
 
             if (mediaTypeHeaderValue.MediaType.Equals(ContentTypes.ApplicationFhirXml, StringComparison.OrdinalIgnoreCase))
             {
                 var logger = scope.ServiceProvider.GetService<ILogger<FhirXmlReader>>() ?? throw new ServiceNotFoundException(nameof(ILogger<FhirXmlReader>));
-                return new FhirXmlReader(logger);
+                return new FhirXmlReader(logger, _configuration, _fileSystem);
             }
 
             throw new UnsupportedContentTypeException($"Media type of '{mediaTypeHeaderValue.MediaType}' is not supported.");

--- a/src/InformaticsGateway/Services/Fhir/FhirXmlReader.cs
+++ b/src/InformaticsGateway/Services/Fhir/FhirXmlReader.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.IO;
+using System.IO.Abstractions;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,9 +24,11 @@ using System.Xml;
 using Ardalis.GuardClauses;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 using Monai.Deploy.InformaticsGateway.Api.Storage;
 using Monai.Deploy.InformaticsGateway.Common;
+using Monai.Deploy.InformaticsGateway.Configuration;
 using Monai.Deploy.InformaticsGateway.Logging;
 
 namespace Monai.Deploy.InformaticsGateway.Services.Fhir
@@ -33,10 +36,14 @@ namespace Monai.Deploy.InformaticsGateway.Services.Fhir
     internal class FhirXmlReader : IFHirRequestReader
     {
         private readonly ILogger<FhirXmlReader> _logger;
+        private readonly IOptions<InformaticsGatewayConfiguration> _options;
+        private readonly IFileSystem _fileSystem;
 
-        public FhirXmlReader(ILogger<FhirXmlReader> logger)
+        public FhirXmlReader(ILogger<FhirXmlReader> logger, IOptions<InformaticsGatewayConfiguration> options, IFileSystem fileSystem)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
         }
 
         public async Task<FhirStoreResult> GetContentAsync(HttpRequest request, string correlationId, string resourceType, MediaTypeHeaderValue mediaTypeHeaderValue, CancellationToken cancellationToken)
@@ -80,7 +87,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Fhir
             result.InternalResourceType = rootNode.Name;
 
             var fileMetadata = new FhirFileStorageMetadata(correlationId, result.InternalResourceType, resourceId, Api.Rest.FhirStorageFormat.Xml);
-            fileMetadata.SetDataStream(result.RawData);
+            await fileMetadata.SetDataStream(result.RawData, _options.Value.Storage.TemporaryDataStorage, _fileSystem, _options.Value.Storage.BufferStorageRootPath);
 
             result.Metadata = fileMetadata;
             return result;

--- a/src/InformaticsGateway/Services/Scp/ApplicationEntityHandler.cs
+++ b/src/InformaticsGateway/Services/Scp/ApplicationEntityHandler.cs
@@ -15,12 +15,14 @@
  */
 
 using System;
+using System.IO.Abstractions;
 using System.Linq;
 using System.Threading.Tasks;
 using Ardalis.GuardClauses;
 using FellowOakDicom.Network;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Monai.Deploy.InformaticsGateway.Api;
 using Monai.Deploy.InformaticsGateway.Api.Storage;
 using Monai.Deploy.InformaticsGateway.Common;
@@ -34,11 +36,12 @@ namespace Monai.Deploy.InformaticsGateway.Services.Scp
     internal class ApplicationEntityHandler : IDisposable, IApplicationEntityHandler
     {
         private readonly ILogger<ApplicationEntityHandler> _logger;
+        private readonly IOptions<InformaticsGatewayConfiguration> _options;
 
         private readonly IServiceScope _serviceScope;
         private readonly IPayloadAssembler _payloadAssembler;
         private readonly IObjectUploadQueue _uploadQueue;
-
+        private readonly IFileSystem _fileSystem;
         private MonaiApplicationEntity _configuration;
         private DicomJsonOptions _dicomJsonOptions;
         private bool _validateDicomValueOnJsonSerialization;
@@ -46,14 +49,17 @@ namespace Monai.Deploy.InformaticsGateway.Services.Scp
 
         public ApplicationEntityHandler(
             IServiceScopeFactory serviceScopeFactory,
-            ILogger<ApplicationEntityHandler> logger)
+            ILogger<ApplicationEntityHandler> logger,
+            IOptions<InformaticsGatewayConfiguration> options)
         {
             Guard.Against.Null(serviceScopeFactory, nameof(serviceScopeFactory));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
 
             _serviceScope = serviceScopeFactory.CreateScope();
             _payloadAssembler = _serviceScope.ServiceProvider.GetService<IPayloadAssembler>() ?? throw new ServiceNotFoundException(nameof(IPayloadAssembler));
             _uploadQueue = _serviceScope.ServiceProvider.GetService<IObjectUploadQueue>() ?? throw new ServiceNotFoundException(nameof(IObjectUploadQueue));
+            _fileSystem = _serviceScope.ServiceProvider.GetService<IFileSystem>() ?? throw new ServiceNotFoundException(nameof(IFileSystem));
         }
 
         public void Configure(MonaiApplicationEntity monaiApplicationEntity, DicomJsonOptions dicomJsonOptions, bool validateDicomValuesOnJsonSerialization)
@@ -95,7 +101,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Scp
                 dicomInfo.SetWorkflows(_configuration.Workflows.ToArray());
             }
 
-            await dicomInfo.SetDataStreams(request.File, request.File.ToJson(_dicomJsonOptions, _validateDicomValueOnJsonSerialization)).ConfigureAwait(false);
+            await dicomInfo.SetDataStreams(request.File, request.File.ToJson(_dicomJsonOptions, _validateDicomValueOnJsonSerialization), _options.Value.Storage.TemporaryDataStorage, _fileSystem, _options.Value.Storage.BufferStorageRootPath).ConfigureAwait(false);
             _uploadQueue.Queue(dicomInfo);
 
             var dicomTag = FellowOakDicom.DicomTag.Parse(_configuration.Grouping);

--- a/src/InformaticsGateway/Test/Common/DicomFileStorageMetadataExtensionsTest.cs
+++ b/src/InformaticsGateway/Test/Common/DicomFileStorageMetadataExtensionsTest.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.IO;
+using System.IO.Abstractions.TestingHelpers;
 using System.Text;
 using System.Threading.Tasks;
 using FellowOakDicom;
@@ -31,7 +32,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Common
     public class DicomFileStorageMetadataExtensionsTest
     {
         [Fact]
-        public async Task GivenADicomFileStorageMetadata_WhenSetDataStreamsIsCalled_ExpectDataStreamsAreSet()
+        public async Task GivenADicomFileStorageMetadata_WhenSetDataStreamsIsCalledWithInMemoryStore_ExpectDataStreamsAreSet()
         {
             var metadata = new DicomFileStorageMetadata(
                 Guid.NewGuid().ToString(),
@@ -42,7 +43,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Common
 
             var dicom = InstanceGenerator.GenerateDicomFile();
             var json = dicom.ToJson(DicomJsonOptions.Complete, false);
-            await metadata.SetDataStreams(dicom, json).ConfigureAwait(false);
+            await metadata.SetDataStreams(dicom, json, TemporaryDataStorageLocation.Memory).ConfigureAwait(false);
 
             Assert.NotNull(metadata.File.Data);
             Assert.NotNull(metadata.JsonFile.Data);
@@ -59,7 +60,38 @@ namespace Monai.Deploy.InformaticsGateway.Test.Common
         }
 
         [Fact]
-        public async Task GivenADicomFileStorageMetadataWithInvalidDSValue_WhenSetDataStreamsIsCalledWithValidation_ThrowsFormatException()
+        public async Task GivenADicomFileStorageMetadata_WhenSetDataStreamsIsCalledWithDiskStore_ExpectDataStreamsAreSet()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory("/temp");
+
+            var metadata = new DicomFileStorageMetadata(
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString());
+
+            var dicom = InstanceGenerator.GenerateDicomFile();
+            var json = dicom.ToJson(DicomJsonOptions.Complete, false);
+            await metadata.SetDataStreams(dicom, json, TemporaryDataStorageLocation.Disk, fileSystem, "/temp").ConfigureAwait(false);
+
+            Assert.NotNull(metadata.File.Data);
+            Assert.NotNull(metadata.JsonFile.Data);
+
+            var ms = new MemoryStream();
+            await dicom.SaveAsync(ms).ConfigureAwait(false);
+            Assert.Equal(ms.ToArray(), (metadata.File.Data as MemoryStream).ToArray());
+
+            var jsonFromStream = Encoding.UTF8.GetString((metadata.JsonFile.Data as MemoryStream).ToArray());
+            Assert.Equal(json.Trim(), jsonFromStream.Trim());
+
+            var dicomFileFromJson = DicomJson.ConvertJsonToDicom(json);
+            Assert.Equal(dicom.Dataset, dicomFileFromJson);
+        }
+
+        [Fact]
+        public void GivenADicomFileStorageMetadataWithInvalidDSValue_WhenSetDataStreamsIsCalledWithValidation_ThrowsFormatException()
         {
             var metadata = new DicomFileStorageMetadata(
                 Guid.NewGuid().ToString(),
@@ -94,7 +126,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Common
             dicom.Dataset.Add(DicomTag.PixelSpacing, "0.68300002813334234392234", "0.2354257587243524352345");
 
             var json = dicom.ToJson(DicomJsonOptions.Complete, false);
-            await metadata.SetDataStreams(dicom, json).ConfigureAwait(false);
+            await metadata.SetDataStreams(dicom, json, TemporaryDataStorageLocation.Memory).ConfigureAwait(false);
 
             Assert.NotNull(metadata.File.Data);
             Assert.NotNull(metadata.JsonFile.Data);

--- a/src/InformaticsGateway/Test/Services/Connectors/DataRetrievalServiceTest.cs
+++ b/src/InformaticsGateway/Test/Services/Connectors/DataRetrievalServiceTest.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
@@ -54,6 +55,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
         private readonly Mock<IObjectUploadQueue> _uploadQueue;
         private readonly Mock<IPayloadAssembler> _payloadAssembler;
         private readonly Mock<IDicomToolkit> _dicomToolkit;
+        private readonly Mock<IFileSystem> _fileSystem;
         private readonly Mock<IInferenceRequestRepository> _inferenceRequestStore;
 
         private readonly Mock<ILogger<DicomWebClient>> _loggerDicomWebClient;
@@ -74,6 +76,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
             _serviceScopeFactory = new Mock<IServiceScopeFactory>();
             _uploadQueue = new Mock<IObjectUploadQueue>();
             _dicomToolkit = new Mock<IDicomToolkit>();
+            _fileSystem = new Mock<IFileSystem>();
             _options = Options.Create(new InformaticsGatewayConfiguration());
             _serviceScope = new Mock<IServiceScope>();
 
@@ -90,6 +93,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
             services.AddScoped(p => _payloadAssembler.Object);
             services.AddScoped(p => _dicomToolkit.Object);
             services.AddScoped(p => _inferenceRequestStore.Object);
+            services.AddScoped(p => _fileSystem.Object);
 
             _serviceProvider = services.BuildServiceProvider();
             _serviceScopeFactory.Setup(p => p.CreateScope()).Returns(_serviceScope.Object);

--- a/src/InformaticsGateway/Test/Services/DicomWeb/StreamsWriterTest.cs
+++ b/src/InformaticsGateway/Test/Services/DicomWeb/StreamsWriterTest.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions.TestingHelpers;
 using System.Threading.Tasks;
 using FellowOakDicom;
 using FellowOakDicom.Network;
@@ -38,6 +39,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.DicomWeb
     public class StreamsWriterTest
     {
         private readonly Mock<ILogger<StreamsWriter>> _logger;
+        private readonly MockFileSystem _fileSystem;
         private readonly Mock<IObjectUploadQueue> _uploadQueue;
         private readonly Mock<IDicomToolkit> _dicomToolkit;
         private readonly Mock<IPayloadAssembler> _payloadAssembler;
@@ -50,17 +52,19 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.DicomWeb
             _payloadAssembler = new Mock<IPayloadAssembler>();
             _configuration = Options.Create(new InformaticsGatewayConfiguration());
             _logger = new Mock<ILogger<StreamsWriter>>();
+            _fileSystem = new MockFileSystem();
         }
 
         [Fact]
         public void GivenAStreamsWriter_WhenInitialized_ExpectParametersToBeValidated()
         {
-            Assert.Throws<ArgumentNullException>(() => new StreamsWriter(null, null, null, null, null));
-            Assert.Throws<ArgumentNullException>(() => new StreamsWriter(_uploadQueue.Object, null, null, null, null));
-            Assert.Throws<ArgumentNullException>(() => new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, null, null, null));
-            Assert.Throws<ArgumentNullException>(() => new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, null, null));
-            Assert.Throws<ArgumentNullException>(() => new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, _configuration, null));
-            var exception = Record.Exception(() => new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, _configuration, _logger.Object));
+            Assert.Throws<ArgumentNullException>(() => new StreamsWriter(null, null, null, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new StreamsWriter(_uploadQueue.Object, null, null, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, null, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, _configuration, null, null));
+            Assert.Throws<ArgumentNullException>(() => new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, _configuration, _logger.Object, null));
+            var exception = Record.Exception(() => new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, _configuration, _logger.Object, _fileSystem));
 
             Assert.Null(exception);
         }
@@ -72,7 +76,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.DicomWeb
                 .Throws(new Exception("error"));
 
             var studyInstanceUid = DicomUIDGenerator.GenerateDerivedFromUUID().UID;
-            var writer = new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, _configuration, _logger.Object);
+            var writer = new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, _configuration, _logger.Object, _fileSystem);
 
             var streams = GenerateDicomStreams(studyInstanceUid);
             var result = await writer.Save(
@@ -94,7 +98,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.DicomWeb
             _payloadAssembler.Setup(p => p.Queue(It.IsAny<string>(), It.IsAny<DicomFileStorageMetadata>(), It.IsAny<uint>()));
 
             var studyInstanceUid = DicomUIDGenerator.GenerateDerivedFromUUID().UID;
-            var writer = new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, _configuration, _logger.Object);
+            var writer = new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, _configuration, _logger.Object, _fileSystem);
 
             var correlationId = Guid.NewGuid().ToString();
             var streams = GenerateDicomStreams(studyInstanceUid);
@@ -132,7 +136,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.DicomWeb
             _payloadAssembler.Setup(p => p.Queue(It.IsAny<string>(), It.IsAny<DicomFileStorageMetadata>(), It.IsAny<uint>()));
 
             var studyInstanceUid = DicomUIDGenerator.GenerateDerivedFromUUID().UID;
-            var writer = new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, _configuration, _logger.Object);
+            var writer = new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, _configuration, _logger.Object, _fileSystem);
 
             var correlationId = Guid.NewGuid().ToString();
             var streams = GenerateDicomStreams(studyInstanceUid);

--- a/src/InformaticsGateway/Test/Services/Fhir/FhirJsonReaderTest.cs
+++ b/src/InformaticsGateway/Test/Services/Fhir/FhirJsonReaderTest.cs
@@ -16,11 +16,14 @@
 
 using System;
 using System.IO;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 using Monai.Deploy.InformaticsGateway.Configuration;
 using Monai.Deploy.InformaticsGateway.Services.Fhir;
@@ -31,13 +34,15 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
 {
     public class FhirJsonReaderTest
     {
-        private readonly InformaticsGatewayConfiguration _config;
         private readonly Mock<ILogger<FhirJsonReader>> _logger;
+        private readonly IOptions<InformaticsGatewayConfiguration> _options;
+        private readonly IFileSystem _fileSystem;
 
         public FhirJsonReaderTest()
         {
-            _config = new InformaticsGatewayConfiguration();
             _logger = new Mock<ILogger<FhirJsonReader>>();
+            _options = Options.Create<InformaticsGatewayConfiguration>(new InformaticsGatewayConfiguration());
+            _fileSystem = new MockFileSystem();
         }
 
         [Fact]
@@ -46,7 +51,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             var request = new Mock<HttpRequest>();
             var correlationId = Guid.NewGuid().ToString();
             var resourceType = "Patient";
-            var reader = new FhirJsonReader(_logger.Object);
+            var reader = new FhirJsonReader(_logger.Object, _options, _fileSystem);
 
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await reader.GetContentAsync(null, null, null, null, CancellationToken.None));
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await reader.GetContentAsync(request.Object, null, null, null, CancellationToken.None));
@@ -62,7 +67,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             var correlationId = Guid.NewGuid().ToString();
             var resourceType = "Patient";
             var contentType = new MediaTypeHeaderValue(ContentTypes.ApplicationFhirJson);
-            var reader = new FhirJsonReader(_logger.Object);
+            var reader = new FhirJsonReader(_logger.Object, _options, _fileSystem);
 
             await Assert.ThrowsAsync<ArgumentNullException>(async () =>
             {
@@ -83,7 +88,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             var correlationId = Guid.NewGuid().ToString();
             var resourceType = "Patient";
             var contentType = new MediaTypeHeaderValue(ContentTypes.ApplicationFhirJson);
-            var reader = new FhirJsonReader(_logger.Object);
+            var reader = new FhirJsonReader(_logger.Object, _options, _fileSystem);
 
             await Assert.ThrowsAnyAsync<JsonException>(async () =>
             {
@@ -106,7 +111,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             var correlationId = Guid.NewGuid().ToString();
             var resourceType = "Patient";
             var contentType = new MediaTypeHeaderValue(ContentTypes.ApplicationFhirJson);
-            var reader = new FhirJsonReader(_logger.Object);
+            var reader = new FhirJsonReader(_logger.Object, _options, _fileSystem);
 
             var data = System.Text.Encoding.UTF8.GetBytes(xml);
             using var stream = new System.IO.MemoryStream();

--- a/src/InformaticsGateway/Test/Services/Fhir/FhirServiceTest.cs
+++ b/src/InformaticsGateway/Test/Services/Fhir/FhirServiceTest.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.IO;
+using System.IO.Abstractions;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -43,6 +44,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
         private readonly Mock<ILogger<FhirService>> _logger;
         private readonly Mock<ILogger<FhirJsonReader>> _loggerJson;
         private readonly Mock<ILogger<FhirXmlReader>> _loggerXml;
+        private readonly Mock<IFileSystem> _fileSystem;
         private readonly Mock<IPayloadAssembler> _payloadAssembler;
         private readonly Mock<IObjectUploadQueue> _uploadQueue;
 
@@ -62,6 +64,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             _logger = new Mock<ILogger<FhirService>>();
             _loggerJson = new Mock<ILogger<FhirJsonReader>>();
             _loggerXml = new Mock<ILogger<FhirXmlReader>>();
+            _fileSystem = new Mock<IFileSystem>();
 
             _httpRequest = new Mock<HttpRequest>();
 
@@ -73,6 +76,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             services.AddScoped(p => _loggerXml.Object);
             services.AddScoped(p => _uploadQueue.Object);
             services.AddScoped(p => _payloadAssembler.Object);
+            services.AddScoped(p => _fileSystem.Object);
             _serviceProvider = services.BuildServiceProvider();
             _serviceScopeFactory.Setup(p => p.CreateScope()).Returns(_serviceScope.Object);
             _serviceScope.Setup(p => p.ServiceProvider).Returns(_serviceProvider);

--- a/src/InformaticsGateway/Test/Services/Fhir/FhirXmlReaderTest.cs
+++ b/src/InformaticsGateway/Test/Services/Fhir/FhirXmlReaderTest.cs
@@ -16,12 +16,16 @@
 
 using System;
 using System.IO;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
+using Monai.Deploy.InformaticsGateway.Configuration;
 using Monai.Deploy.InformaticsGateway.Services.Fhir;
 using Moq;
 using Xunit;
@@ -31,10 +35,15 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
     public class FhirXmlReaderTest
     {
         private readonly Mock<ILogger<FhirXmlReader>> _logger;
+        private readonly IOptions<InformaticsGatewayConfiguration> _options;
+        private readonly IFileSystem _fileSystem;
 
         public FhirXmlReaderTest()
         {
             _logger = new Mock<ILogger<FhirXmlReader>>();
+            _options = Options.Create<InformaticsGatewayConfiguration>(new InformaticsGatewayConfiguration());
+            _fileSystem = new MockFileSystem();
+
         }
 
         [Fact]
@@ -43,7 +52,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             var request = new Mock<HttpRequest>();
             var correlationId = Guid.NewGuid().ToString();
             var resourceType = "Patient";
-            var reader = new FhirXmlReader(_logger.Object);
+            var reader = new FhirXmlReader(_logger.Object, _options, _fileSystem);
 
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await reader.GetContentAsync(null, null, null, null, CancellationToken.None));
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await reader.GetContentAsync(request.Object, null, null, null, CancellationToken.None));
@@ -59,7 +68,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             var correlationId = Guid.NewGuid().ToString();
             var resourceType = "Patient";
             var contentType = new MediaTypeHeaderValue(ContentTypes.ApplicationFhirXml);
-            var reader = new FhirXmlReader(_logger.Object);
+            var reader = new FhirXmlReader(_logger.Object, _options, _fileSystem);
 
             await Assert.ThrowsAsync<ArgumentNullException>(async () =>
             {
@@ -80,7 +89,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             var correlationId = Guid.NewGuid().ToString();
             var resourceType = "Patient";
             var contentType = new MediaTypeHeaderValue(ContentTypes.ApplicationFhirXml);
-            var reader = new FhirXmlReader(_logger.Object);
+            var reader = new FhirXmlReader(_logger.Object, _options, _fileSystem);
 
             await Assert.ThrowsAsync<XmlException>(async () =>
             {
@@ -100,7 +109,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             var correlationId = Guid.NewGuid().ToString();
             var resourceType = "Patient";
             var contentType = new MediaTypeHeaderValue(ContentTypes.ApplicationFhirXml);
-            var reader = new FhirXmlReader(_logger.Object);
+            var reader = new FhirXmlReader(_logger.Object, _options, _fileSystem);
 
             await Assert.ThrowsAsync<FhirStoreException>(async () =>
             {
@@ -123,7 +132,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             var correlationId = Guid.NewGuid().ToString();
             var resourceType = "Patient";
             var contentType = new MediaTypeHeaderValue(ContentTypes.ApplicationFhirXml);
-            var reader = new FhirXmlReader(_logger.Object);
+            var reader = new FhirXmlReader(_logger.Object, _options, _fileSystem);
 
             var data = System.Text.Encoding.UTF8.GetBytes(xml);
             using var stream = new System.IO.MemoryStream();

--- a/src/InformaticsGateway/Test/Services/HealthLevel7/MllpServiceTest.cs
+++ b/src/InformaticsGateway/Test/Services/HealthLevel7/MllpServiceTest.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO.Abstractions;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -47,7 +48,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.HealthLevel7
         private readonly Mock<IObjectUploadQueue> _uploadQueue;
         private readonly Mock<IPayloadAssembler> _payloadAssembler;
         private readonly Mock<ITcpListener> _tcpListener;
-
+        private readonly Mock<IFileSystem> _fileSystem;
         private readonly CancellationTokenSource _cancellationTokenSource;
         private readonly Mock<IServiceScope> _serviceScope;
         private readonly Mock<ILogger<MllpService>> _logger;
@@ -64,6 +65,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.HealthLevel7
             _uploadQueue = new Mock<IObjectUploadQueue>();
             _payloadAssembler = new Mock<IPayloadAssembler>();
             _tcpListener = new Mock<ITcpListener>();
+            _fileSystem = new Mock<IFileSystem>();
 
             _cancellationTokenSource = new CancellationTokenSource();
             _serviceScope = new Mock<IServiceScope>();
@@ -77,6 +79,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.HealthLevel7
             services.AddScoped(p => _mllpClientFactory.Object);
             services.AddScoped(p => _uploadQueue.Object);
             services.AddScoped(p => _payloadAssembler.Object);
+            services.AddScoped(p => _fileSystem.Object);
             _serviceProvider = services.BuildServiceProvider();
             _serviceScopeFactory.Setup(p => p.CreateScope()).Returns(_serviceScope.Object);
             _serviceScope.Setup(p => p.ServiceProvider).Returns(_serviceProvider);

--- a/src/InformaticsGateway/Test/Services/Scp/ApplicationEntityHandlerTest.cs
+++ b/src/InformaticsGateway/Test/Services/Scp/ApplicationEntityHandlerTest.cs
@@ -16,14 +16,17 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO.Abstractions;
 using System.Threading.Tasks;
 using FellowOakDicom;
 using FellowOakDicom.Network;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Monai.Deploy.InformaticsGateway.Api;
 using Monai.Deploy.InformaticsGateway.Api.Storage;
 using Monai.Deploy.InformaticsGateway.Common;
+using Monai.Deploy.InformaticsGateway.Configuration;
 using Monai.Deploy.InformaticsGateway.Services.Connectors;
 using Monai.Deploy.InformaticsGateway.Services.Scp;
 using Monai.Deploy.InformaticsGateway.Services.Storage;
@@ -41,7 +44,8 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Scp
         private readonly Mock<IServiceScope> _serviceScope;
         private readonly Mock<IPayloadAssembler> _payloadAssembler;
         private readonly Mock<IObjectUploadQueue> _uploadQueue;
-
+        private readonly IOptions<InformaticsGatewayConfiguration> _options;
+        private readonly Mock<IFileSystem> _fileSystem;
         private readonly IServiceProvider _serviceProvider;
 
         public ApplicationEntityHandlerTest()
@@ -52,10 +56,13 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Scp
 
             _payloadAssembler = new Mock<IPayloadAssembler>();
             _uploadQueue = new Mock<IObjectUploadQueue>();
+            _options = Options.Create<InformaticsGatewayConfiguration>(new InformaticsGatewayConfiguration());
+            _fileSystem = new Mock<IFileSystem>();
 
             var services = new ServiceCollection();
             services.AddScoped(p => _payloadAssembler.Object);
             services.AddScoped(p => _uploadQueue.Object);
+            services.AddScoped(p => _fileSystem.Object);
             _serviceProvider = services.BuildServiceProvider();
             _serviceScopeFactory.Setup(p => p.CreateScope()).Returns(_serviceScope.Object);
             _serviceScope.Setup(p => p.ServiceProvider).Returns(_serviceProvider);
@@ -66,10 +73,11 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Scp
         [RetryFact(5, 250)]
         public void GivenAApplicationEntityHandler_WhenInitialized_ExpectParametersToBeValidated()
         {
-            Assert.Throws<ArgumentNullException>(() => new ApplicationEntityHandler(null, null));
-            Assert.Throws<ArgumentNullException>(() => new ApplicationEntityHandler(_serviceScopeFactory.Object, null));
+            Assert.Throws<ArgumentNullException>(() => new ApplicationEntityHandler(null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new ApplicationEntityHandler(_serviceScopeFactory.Object, null, null));
+            Assert.Throws<ArgumentNullException>(() => new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object, null));
 
-            _ = new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object);
+            _ = new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object, _options);
         }
 
         [RetryFact(5, 250)]
@@ -83,7 +91,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Scp
                 IgnoredSopClasses = new List<string> { DicomUID.SecondaryCaptureImageStorage.UID }
             };
 
-            var handler = new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object);
+            var handler = new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object, _options);
 
             var request = GenerateRequest();
             var dicomToolkit = new DicomToolkit();
@@ -103,7 +111,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Scp
                 IgnoredSopClasses = new List<string> { DicomUID.SecondaryCaptureImageStorage.UID }
             };
 
-            var handler = new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object);
+            var handler = new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object, _options);
             handler.Configure(aet, Configuration.DicomJsonOptions.Complete, true);
 
             var request = GenerateRequest();
@@ -127,7 +135,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Scp
                 AllowedSopClasses = new List<string> { DicomUID.UltrasoundImageStorage.UID }
             };
 
-            var handler = new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object);
+            var handler = new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object, _options);
             handler.Configure(aet, Configuration.DicomJsonOptions.Complete, true);
 
             var request = GenerateRequest();
@@ -150,7 +158,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Scp
                 Workflows = new List<string>() { "AppA", "AppB", Guid.NewGuid().ToString() }
             };
 
-            var handler = new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object);
+            var handler = new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object, _options);
             handler.Configure(aet, Configuration.DicomJsonOptions.Complete, true);
 
             var request = GenerateRequest();

--- a/src/InformaticsGateway/Test/Services/Storage/ObjectUploadServiceTest.cs
+++ b/src/InformaticsGateway/Test/Services/Storage/ObjectUploadServiceTest.cs
@@ -45,7 +45,6 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Storage
         private readonly IObjectUploadQueue _uploadQueue;
         private readonly Mock<IStorageService> _storageService;
         private readonly Mock<IStorageMetadataWrapperRepository> _storageMetadataWrapperRepository;
-
         private readonly CancellationTokenSource _cancellationTokenSource;
         private readonly ServiceProvider _serviceProvider;
         private readonly Mock<IServiceScope> _serviceScope;
@@ -124,7 +123,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Storage
         }
 
         [Fact]
-        public void GivenAFhirFileStorageMetadata_WhenQueuedForUpload_ExpectSingleFileToBeUploaded()
+        public async Task GivenAFhirFileStorageMetadata_WhenQueuedForUpload_ExpectSingleFileToBeUploaded()
         {
             var countdownEvent = new CountdownEvent(1);
             _storageService.Setup(p => p.PutObjectAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<long>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
@@ -137,7 +136,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Storage
 
             Assert.Equal(ServiceStatus.Running, svc.Status);
 
-            var file = GenerateFhirFileStorageMetadata();
+            var file = await GenerateFhirFileStorageMetadata();
             _uploadQueue.Queue(file);
 
             Assert.True(countdownEvent.Wait(TimeSpan.FromSeconds(3)));
@@ -145,11 +144,11 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Storage
             _storageService.Verify(p => p.PutObjectAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<long>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()), Times.Once());
         }
 
-        private FhirFileStorageMetadata GenerateFhirFileStorageMetadata()
+        private async Task<FhirFileStorageMetadata> GenerateFhirFileStorageMetadata()
         {
             var file = new FhirFileStorageMetadata(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), FhirStorageFormat.Json);
 
-            file.SetDataStream("[]");
+            await file.SetDataStream("[]", TemporaryDataStorageLocation.Memory);
             return file;
         }
 
@@ -169,7 +168,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Storage
                 { DicomTag.SOPClassUID, DicomUID.SecondaryCaptureImageStorage.UID }
             };
             var dicomFile = new DicomFile(dataset);
-            await file.SetDataStreams(dicomFile, "[]");
+            await file.SetDataStreams(dicomFile, "[]", TemporaryDataStorageLocation.Memory);
             return file;
         }
     }


### PR DESCRIPTION
### Description

Fixes #154

- Added new configurations (`tempStorageLocation`) to enable users to use either `Memory` or `Disk` (default) for storing incoming data.  
- For `disk` option:
  - users must configure `bufferRootPath`.
  - `bufferSize` allows users to set disk buffer size with a default value of 128KB
- For `Memory` option:
  - `GC.Collect` is called upon a successful upload to force the garbage collector to compact the LOH


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] I have updated the changelog
