### PR TITLE
Ability to switch temporary storage to use either memory or disk

### DIFF
--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -18,7 +18,7 @@
   - :who: mocsharp
     :why: Apache-2.0 (https://github.com/aws/aws-sdk-net/raw/master/License.txt)
     :versions:
-    - 3.7.12.26
+    - 3.7.13.8
     :when: 2022-09-01 23:05:22.203089302 Z
 - - :approve
   - AWSSDK.S3
@@ -32,7 +32,7 @@
   - :who: mocsharp
     :why: Apache-2.0 (https://github.com/aws/aws-sdk-net/raw/master/License.txt)
     :versions:
-    - 3.7.1.190
+    - 3.7.1.203
     :when: 2022-09-01 23:05:28.920368903 Z
 - - :approve
   - BoDi
@@ -851,35 +851,35 @@
   - :who: mocsharp
     :why: Apache-2.0 (https://github.com/Project-MONAI/monai-deploy-messaging/raw/main/LICENSE)
     :versions:
-    - 0.1.4
+    - 0.1.5
     :when: 2022-08-16 23:06:21.051573547 Z
 - - :approve
   - Monai.Deploy.Messaging.RabbitMQ
   - :who: mocsharp
     :why: Apache-2.0 (https://github.com/Project-MONAI/monai-deploy-messaging/raw/main/LICENSE)
     :versions:
-    - 0.1.4
+    - 0.1.5
     :when: 2022-08-16 23:06:21.511789690 Z
 - - :approve
   - Monai.Deploy.Storage
   - :who: mocsharp
     :why: Apache-2.0 (https://github.com/Project-MONAI/monai-deploy-storage/raw/main/LICENSE)
     :versions:
-    - 0.2.5
+    - 0.2.7
     :when: 2022-08-16 23:06:21.988183476 Z
 - - :approve
   - Monai.Deploy.Storage.MinIO
   - :who: mocsharp
     :why: Apache-2.0 (https://github.com/Project-MONAI/monai-deploy-storage/raw/main/LICENSE)
     :versions:
-    - 0.2.5
+    - 0.2.7
     :when: 2022-08-16 23:06:22.426838304 Z
 - - :approve
   - Monai.Deploy.Storage.S3Policy
   - :who: mocsharp
     :why: Apache-2.0 (https://github.com/Project-MONAI/monai-deploy-storage/raw/main/LICENSE)
     :versions:
-    - 0.2.5
+    - 0.2.7
     :when: 2022-08-16 23:06:22.881956546 Z
 - - :approve
   - Moq
@@ -1878,6 +1878,7 @@
   - :who: mocsharp
     :why: Microsoft Public License (https://github.com/fo-dicom/fo-dicom/raw/development/License.txt)
     :versions:
+    - 5.0.2
     - 5.0.3
     :when: 2022-08-16 23:07:29.574869349 Z
 - - :approve

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,15 @@
 
 
 # Changelog
+
+## 0.3.1
+
+[GitHub Milestone 0.3.0](https://github.com/Project-MONAI/monai-deploy-informatics-gateway/milestone/7)
+
+- The SCU AE Title is now uppercase MONAISCU.
+- Update fo-dicom to 5.0.3
+- Defaults temporary storage to use disk with ability to switch to memory.
+
 ## 0.3.0
 
 [GitHub Milestone 0.3.0](https://github.com/Project-MONAI/monai-deploy-informatics-gateway/milestone/3)
@@ -36,7 +45,7 @@
   any pending files. Files that were successfully uploaded to the temporary location (`storage>temporary`) in the 
   bucket (`storage>temporaryBucketName`) are then moved to the payload bucket (`storage>bucketName`) before sending a workflow request.  
 - Breaking changes in the storage configuration to allow dynamic key-value pairs.
-- Breaking changes to enable dynamic loadig of the storage & the messaging libraries.
+- Breaking changes to enable dynamic loading of the storage & the messaging libraries.
 
 ## 0.1.1
 

--- a/docs/compliance/third-party-licenses.md
+++ b/docs/compliance/third-party-licenses.md
@@ -60,15 +60,15 @@ SOFTWARE.
 
 
 <details>
-<summary>AWSSDK.Core 3.7.12.26</summary>
+<summary>AWSSDK.Core 3.7.13.8</summary>
 
 ## AWSSDK.Core
 
-- Version: 3.7.12.26
+- Version: 3.7.13.8
 - Authors: Amazon Web Services
 - Owners: Amazon Web Services
 - Project URL: https://github.com/aws/aws-sdk-net/
-- Source: [NuGet](https://www.nuget.org/packages/AWSSDK.Core/3.7.12.26)
+- Source: [NuGet](https://www.nuget.org/packages/AWSSDK.Core/3.7.13.8)
 - License: [Apache-2.0](https://github.com/aws/aws-sdk-net/raw/master/License.txt)
 
 
@@ -206,15 +206,15 @@ END OF TERMS AND CONDITIONS
 
 
 <details>
-<summary>AWSSDK.SecurityToken 3.7.1.190</summary>
+<summary>AWSSDK.SecurityToken 3.7.1.203</summary>
 
 ## AWSSDK.SecurityToken
 
-- Version: 3.7.1.190
+- Version: 3.7.1.203
 - Authors: Amazon Web Services
 - Owners: Amazon Web Services
 - Project URL: https://github.com/aws/aws-sdk-net/
-- Source: [NuGet](https://www.nuget.org/packages/AWSSDK.SecurityToken/3.7.1.190)
+- Source: [NuGet](https://www.nuget.org/packages/AWSSDK.SecurityToken/3.7.1.203)
 - License: [Apache-2.0](https://github.com/aws/aws-sdk-net/raw/master/License.txt)
 
 
@@ -6580,11 +6580,10 @@ SOFTWARE.
 ## Microsoft.Toolkit.HighPerformance
 
 - Version: 7.1.2
-- Authors: Microsoft
-- Owners: Microsoft.Toolkit,dotnetfoundation
-- Project URL: https://dot.net/
+- Authors: Microsoft.Toolkit
+- Project URL: https://github.com/CommunityToolkit/WindowsCommunityToolkit
 - Source: [NuGet](https://www.nuget.org/packages/Microsoft.Toolkit.HighPerformance/7.1.2)
-- License: [MIT]( https://github.com/CommunityToolkit/WindowsCommunityToolkit/raw/main/License.md)
+- License: [MIT](https://github.com/CommunityToolkit/WindowsCommunityToolkit/raw/main/License.md)
 
 
 ```
@@ -6596,19 +6595,16 @@ All rights reserved.
 
 ## MIT License (MIT)
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”),
-to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
 </details>
+
+
 <details>
 <summary>Microsoft.Win32.Primitives 4.3.0</summary>
 
@@ -7290,14 +7286,14 @@ Apache License
 
 
 <details>
-<summary>Monai.Deploy.Messaging 0.1.4</summary>
+<summary>Monai.Deploy.Messaging 0.1.5</summary>
 
 ## Monai.Deploy.Messaging
 
-- Version: 0.1.4
+- Version: 0.1.5
 - Authors: MONAI Consortium
 - Project URL: https://github.com/Project-MONAI/monai-deploy-messaging
-- Source: [NuGet](https://www.nuget.org/packages/Monai.Deploy.Messaging/0.1.4)
+- Source: [NuGet](https://www.nuget.org/packages/Monai.Deploy.Messaging/0.1.5)
 - License: [Apache-2.0](https://github.com/Project-MONAI/monai-deploy-messaging/raw/main/LICENSE)
 
 
@@ -7518,14 +7514,14 @@ By downloading this software, you agree to the license terms & all licenses list
 
 
 <details>
-<summary>Monai.Deploy.Messaging.RabbitMQ 0.1.4</summary>
+<summary>Monai.Deploy.Messaging.RabbitMQ 0.1.5</summary>
 
 ## Monai.Deploy.Messaging.RabbitMQ
 
-- Version: 0.1.4
+- Version: 0.1.5
 - Authors: MONAI Consortium
 - Project URL: https://github.com/Project-MONAI/monai-deploy-messaging
-- Source: [NuGet](https://www.nuget.org/packages/Monai.Deploy.Messaging.RabbitMQ/0.1.4)
+- Source: [NuGet](https://www.nuget.org/packages/Monai.Deploy.Messaging.RabbitMQ/0.1.5)
 - License: [Apache-2.0](https://github.com/Project-MONAI/monai-deploy-messaging/raw/main/LICENSE)
 
 
@@ -7746,14 +7742,14 @@ By downloading this software, you agree to the license terms & all licenses list
 
 
 <details>
-<summary>Monai.Deploy.Storage 0.2.5</summary>
+<summary>Monai.Deploy.Storage 0.2.7</summary>
 
 ## Monai.Deploy.Storage
 
-- Version: 0.2.5
+- Version: 0.2.7
 - Authors: MONAI Consortium
 - Project URL: https://github.com/Project-MONAI/monai-deploy-storage
-- Source: [NuGet](https://www.nuget.org/packages/Monai.Deploy.Storage/0.2.5)
+- Source: [NuGet](https://www.nuget.org/packages/Monai.Deploy.Storage/0.2.7)
 - License: [Apache-2.0](https://github.com/Project-MONAI/monai-deploy-storage/raw/main/LICENSE)
 
 
@@ -7974,14 +7970,14 @@ By downloading this software, you agree to the license terms & all licenses list
 
 
 <details>
-<summary>Monai.Deploy.Storage.MinIO 0.2.5</summary>
+<summary>Monai.Deploy.Storage.MinIO 0.2.7</summary>
 
 ## Monai.Deploy.Storage.MinIO
 
-- Version: 0.2.5
+- Version: 0.2.7
 - Authors: MONAI Consortium
 - Project URL: https://github.com/Project-MONAI/monai-deploy-storage
-- Source: [NuGet](https://www.nuget.org/packages/Monai.Deploy.Storage.MinIO/0.2.5)
+- Source: [NuGet](https://www.nuget.org/packages/Monai.Deploy.Storage.MinIO/0.2.7)
 - License: [Apache-2.0](https://github.com/Project-MONAI/monai-deploy-storage/raw/main/LICENSE)
 
 
@@ -8202,14 +8198,14 @@ By downloading this software, you agree to the license terms & all licenses list
 
 
 <details>
-<summary>Monai.Deploy.Storage.S3Policy 0.2.5</summary>
+<summary>Monai.Deploy.Storage.S3Policy 0.2.7</summary>
 
 ## Monai.Deploy.Storage.S3Policy
 
-- Version: 0.2.5
+- Version: 0.2.7
 - Authors: MONAI Consortium
 - Project URL: https://github.com/Project-MONAI/monai-deploy-storage
-- Source: [NuGet](https://www.nuget.org/packages/Monai.Deploy.Storage.S3Policy/0.2.5)
+- Source: [NuGet](https://www.nuget.org/packages/Monai.Deploy.Storage.S3Policy/0.2.7)
 - License: [Apache-2.0](https://github.com/Project-MONAI/monai-deploy-storage/raw/main/LICENSE)
 
 
@@ -9230,22 +9226,22 @@ resources
 legal and licencing
 contributors
 
- 
+ 
 
 
 Please note: our license is an adaptation of the MIT X11 License and should be read as such.
 Please also note: this licensing model is made possible through funding from donations and the sale of support contracts.
 License
 Copyright (c) 2000 - 2017 The Legion of the Bouncy Castle Inc. (http://www.bouncycastle.org)
-            Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-            The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-            THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+			Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+			The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+			THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-        
- 
+		
+ 
 
 
- 
+ 
 
 
 Site hosted by Tau Ceti Co-operative Ltd.
@@ -27551,6 +27547,311 @@ SOFTWARE.
 
 
 <details>
+<summary>fo-dicom 5.0.2</summary>
+
+## fo-dicom
+
+- Version: 5.0.2
+- Authors: fo-dicom contributors
+- Project URL: https://github.com/fo-dicom/fo-dicom
+- Source: [NuGet](https://www.nuget.org/packages/fo-dicom/5.0.2)
+- License: [Microsoft Public License](https://github.com/fo-dicom/fo-dicom/raw/development/License.txt)
+
+
+```
+Fellow Oak DICOM
+
+Copyright (c) 2012-2021 fo-dicom contributors
+
+This software is licensed under the Microsoft Public License (MS-PL)
+
+Microsoft Public License (MS-PL)
+
+This license governs use of the accompanying software. If you use the software, you
+accept this license. If you do not accept the license, do not use the software.
+
+1. Definitions
+The terms "reproduce," "reproduction," "derivative works," and "distribution" have the
+same meaning here as under U.S. copyright law.
+A "contribution" is the original software, or any additions or changes to the software.
+A "contributor" is any person that distributes its contribution under this license.
+"Licensed patents" are a contributor's patent claims that read directly on its contribution.
+
+2. Grant of Rights
+(A) Copyright Grant- Subject to the terms of this license, including the license conditions 
+    and limitations in section 3, each contributor grants you a non-exclusive, worldwide, 
+	royalty-free copyright license to reproduce its contribution, prepare derivative works 
+	of its contribution, and distribute its contribution or any derivative works that you create.
+(B) Patent Grant- Subject to the terms of this license, including the license conditions and 
+    limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free 
+	license under its licensed patents to make, have made, use, sell, offer for sale, import, 
+	and/or otherwise dispose of its contribution in the software or derivative works of the 
+	contribution in the software.
+
+3. Conditions and Limitations
+(A) No Trademark License- This license does not grant you rights to use any contributors' name, 
+    logo, or trademarks.
+(B) If you bring a patent claim against any contributor over patents that you claim are infringed 
+    by the software, your patent license from such contributor to the software ends automatically.
+(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, 
+    and attribution notices that are present in the software.
+(D) If you distribute any portion of the software in source code form, you may do so only under this 
+    license by including a complete copy of this license with your distribution. If you distribute 
+	any portion of the software in compiled or object code form, you may only do so under a license 
+	that complies with this license.
+(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express 
+    warranties, guarantees or conditions. You may have additional consumer rights under your local 
+	laws which this license cannot change. To the extent permitted under your local laws, the 
+	contributors exclude the implied warranties of merchantability, fitness for a particular purpose 
+	and non-infringement.
+
+
+
+---- libijg (from DCMTK 3.5.4 COPYRIGHT) ----
+
+Unless otherwise specified, the DCMTK software package has the
+following copyright:
+
+/*
+ *  Copyright (C) 1994-2004, OFFIS
+ *
+ *  This software and supporting documentation were developed by
+ *
+ *    Kuratorium OFFIS e.V.
+ *    Healthcare Information and Communication Systems
+ *    Escherweg 2
+ *    D-26121 Oldenburg, Germany
+ *
+ *  THIS SOFTWARE IS MADE AVAILABLE,  AS IS,  AND OFFIS MAKES NO  WARRANTY
+ *  REGARDING  THE  SOFTWARE,  ITS  PERFORMANCE,  ITS  MERCHANTABILITY  OR
+ *  FITNESS FOR ANY PARTICULAR USE, FREEDOM FROM ANY COMPUTER DISEASES  OR
+ *  ITS CONFORMITY TO ANY SPECIFICATION. THE ENTIRE RISK AS TO QUALITY AND
+ *  PERFORMANCE OF THE SOFTWARE IS WITH THE USER.
+ *
+ *  Copyright of the software  and  supporting  documentation  is,  unless
+ *  otherwise stated, owned by OFFIS, and free access is hereby granted as
+ *  a license to  use  this  software,  copy  this  software  and  prepare
+ *  derivative works based upon this software.  However, any  distribution
+ *  of this software source code or supporting documentation or derivative
+ *  works  (source code and  supporting documentation)  must  include  the
+ *  three paragraphs of this copyright notice.
+ *
+ */
+
+The dcmjpeg sub-package includes an adapted version of the Independent JPEG
+Group Toolkit Version 6b, which is contained in dcmjpeg/libijg8,
+dcmjpeg/libijg12 and dcmjpeg/libijg16.  This toolkit is covered by the
+following copyright.  The original README file for the Independent JPEG
+Group Toolkit is located in dcmjpeg/docs/ijg_readme.txt.
+
+/*
+ *  The authors make NO WARRANTY or representation, either express or implied,
+ *  with respect to this software, its quality, accuracy, merchantability, or
+ *  fitness for a particular purpose.  This software is provided "AS IS", and you,
+ *  its user, assume the entire risk as to its quality and accuracy.
+ *
+ *  This software is copyright (C) 1991-1998, Thomas G. Lane.
+ *  All Rights Reserved except as specified below.
+ *
+ *  Permission is hereby granted to use, copy, modify, and distribute this
+ *  software (or portions thereof) for any purpose, without fee, subject to these
+ *  conditions:
+ *  (1) If any part of the source code for this software is distributed, then this
+ *  README file must be included, with this copyright and no-warranty notice
+ *  unaltered; and any additions, deletions, or changes to the original files
+ *  must be clearly indicated in accompanying documentation.
+ *  (2) If only executable code is distributed, then the accompanying
+ *  documentation must state that "this software is based in part on the work of
+ *  the Independent JPEG Group".
+ *  (3) Permission for use of this software is granted only if the user accepts
+ *  full responsibility for any undesirable consequences; the authors accept
+ *  NO LIABILITY for damages of any kind.
+ *
+ *  These conditions apply to any software derived from or based on the IJG code,
+ *  not just to the unmodified library.  If you use our work, you ought to
+ *  acknowledge us.
+ *
+ *  Permission is NOT granted for the use of any IJG author's name or company name
+ *  in advertising or publicity relating to this software or products derived from
+ *  it.  This software may be referred to only as "the Independent JPEG Group's
+ *  software".
+ *
+ *  We specifically permit and encourage the use of this software as the basis of
+ *  commercial products, provided that all warranty or liability claims are
+ *  assumed by the product vendor.
+ */
+
+
+
+---- OpenJPEG JPEG 2000 codec (from license.txt) ----
+
+/*
+ * Copyright (c) 2002-2007, Communications and Remote Sensing Laboratory, Universite catholique de Louvain (UCL), Belgium
+ * Copyright (c) 2002-2007, Professor Benoit Macq
+ * Copyright (c) 2001-2003, David Janssens
+ * Copyright (c) 2002-2003, Yannick Verschueren
+ * Copyright (c) 2003-2007, Francois-Olivier Devaux and Antonin Descampe
+ * Copyright (c) 2005, Herve Drolon, FreeImage Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS `AS IS'
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+
+---- CharLS JPEG-LS codec (from License.txt) ----
+
+Copyright (c) 2007-2009, Jan de Vaan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this 
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, 
+  this list of conditions and the following disclaimer in the documentation 
+  and/or other materials provided with the distribution.
+
+* Neither the name of my employer, nor the names of its contributors may be 
+  used to endorse or promote products derived from this software without 
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON 
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+
+
+
+---- Unity.IO.Compression (from LICENSE.TXT and PATENTS.TXT) ----
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy 
+of this software and associated documentation files (the "Software"), to deal 
+in the Software without restriction, including without limitation the rights 
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom the Software is 
+furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+SOFTWARE.
+
+Microsoft Patent Promise for .NET Libraries and Runtime Components 
+
+Microsoft Corporation and its affiliates ("Microsoft") promise not to assert 
+any .NET Patents against you for making, using, selling, offering for sale, 
+importing, or distributing Covered Code, as part of either a .NET Runtime or 
+as part of any application designed to run on a .NET Runtime. 
+
+If you file, maintain, or voluntarily participate in any claim in a lawsuit 
+alleging direct or contributory patent infringement by any Covered Code, or 
+inducement of patent infringement by any Covered Code, then your rights under 
+this promise will automatically terminate. 
+
+This promise is not an assurance that (i) any .NET Patents are valid or 
+enforceable, or (ii) Covered Code does not infringe patents or other 
+intellectual property rights of any third party. No rights except those 
+expressly stated in this promise are granted, waived, or received by 
+Microsoft, whether by implication, exhaustion, estoppel, or otherwise. 
+This is a personal promise directly from Microsoft to you, and you agree as a 
+condition of benefiting from it that no Microsoft rights are received from 
+suppliers, distributors, or otherwise from any other person in connection with 
+this promise. 
+
+Definitions: 
+
+"Covered Code" means those Microsoft .NET libraries and runtime components as 
+made available by Microsoft at https://github.com/Microsoft/referencesource. 
+
+".NET Patents" are those patent claims, both currently owned by Microsoft and 
+acquired in the future, that are necessarily infringed by Covered Code. .NET 
+Patents do not include any patent claims that are infringed by any Enabling 
+Technology, that are infringed only as a consequence of modification of 
+Covered Code, or that are infringed only by the combination of Covered Code 
+with third party code. 
+
+".NET Runtime" means any compliant implementation in software of (a) all of 
+the required parts of the mandatory provisions of Standard ECMA-335 – Common 
+Language Infrastructure (CLI); and (b) if implemented, any additional 
+functionality in Microsoft's .NET Framework, as described in Microsoft's API 
+documentation on its MSDN website. For example, .NET Runtimes include 
+Microsoft's .NET Framework and those portions of the Mono Project compliant 
+with (a) and (b). 
+
+"Enabling Technology" means underlying or enabling technology that may be 
+used, combined, or distributed in connection with Microsoft's .NET Framework 
+or other .NET Runtimes, such as hardware, operating systems, and applications 
+that run on .NET Framework or other .NET Runtimes. 
+
+
+
+---- Nito.AsyncEx (from LICENSE.TXT) ----
+
+The MIT License (MIT)
+
+Copyright (c) 2014 StephenCleary
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+</details>
+
+
+<details>
 <summary>fo-dicom 5.0.3</summary>
 
 ## fo-dicom
@@ -27584,13 +27885,13 @@ A "contributor" is any person that distributes its contribution under this licen
 2. Grant of Rights
 (A) Copyright Grant- Subject to the terms of this license, including the license conditions 
     and limitations in section 3, each contributor grants you a non-exclusive, worldwide, 
-    royalty-free copyright license to reproduce its contribution, prepare derivative works 
-    of its contribution, and distribute its contribution or any derivative works that you create.
+	royalty-free copyright license to reproduce its contribution, prepare derivative works 
+	of its contribution, and distribute its contribution or any derivative works that you create.
 (B) Patent Grant- Subject to the terms of this license, including the license conditions and 
     limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free 
-    license under its licensed patents to make, have made, use, sell, offer for sale, import, 
-    and/or otherwise dispose of its contribution in the software or derivative works of the 
-    contribution in the software.
+	license under its licensed patents to make, have made, use, sell, offer for sale, import, 
+	and/or otherwise dispose of its contribution in the software or derivative works of the 
+	contribution in the software.
 
 3. Conditions and Limitations
 (A) No Trademark License- This license does not grant you rights to use any contributors' name, 
@@ -27601,13 +27902,13 @@ A "contributor" is any person that distributes its contribution under this licen
     and attribution notices that are present in the software.
 (D) If you distribute any portion of the software in source code form, you may do so only under this 
     license by including a complete copy of this license with your distribution. If you distribute 
-    any portion of the software in compiled or object code form, you may only do so under a license 
-    that complies with this license.
+	any portion of the software in compiled or object code form, you may only do so under a license 
+	that complies with this license.
 (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express 
     warranties, guarantees or conditions. You may have additional consumer rights under your local 
-    laws which this license cannot change. To the extent permitted under your local laws, the 
-    contributors exclude the implied warranties of merchantability, fitness for a particular purpose 
-    and non-infringement.
+	laws which this license cannot change. To the extent permitted under your local laws, the 
+	contributors exclude the implied warranties of merchantability, fitness for a particular purpose 
+	and non-infringement.
 
 
 

--- a/src/Api/Monai.Deploy.InformaticsGateway.Api.csproj
+++ b/src/Api/Monai.Deploy.InformaticsGateway.Api.csproj
@@ -30,8 +30,8 @@
     </PackageReference>
     <PackageReference Include="Macross.Json.Extensions" Version="3.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="6.0.9" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.4" />
-    <PackageReference Include="Monai.Deploy.Storage" Version="0.2.5" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.5" />
+    <PackageReference Include="Monai.Deploy.Storage" Version="0.2.7" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/Api/Storage/Payload.cs
+++ b/src/Api/Storage/Payload.cs
@@ -66,6 +66,8 @@ namespace Monai.Deploy.InformaticsGateway.Api.Storage
 
         public bool HasTimedOut { get => ElapsedTime().TotalSeconds >= Timeout; }
 
+        public TimeSpan Elapsed { get { return DateTime.UtcNow.Subtract(DateTimeCreated); } }
+
         public string CallingAeTitle { get => Files.OfType<DicomFileStorageMetadata>().Select(p => p.CallingAeTitle).FirstOrDefault(); }
 
         public string CalledAeTitle { get => Files.OfType<DicomFileStorageMetadata>().Select(p => p.CalledAeTitle).FirstOrDefault(); }

--- a/src/Configuration/Monai.Deploy.InformaticsGateway.Configuration.csproj
+++ b/src/Configuration/Monai.Deploy.InformaticsGateway.Configuration.csproj
@@ -30,8 +30,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.4" />
-    <PackageReference Include="Monai.Deploy.Storage" Version="0.2.5" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.5" />
+    <PackageReference Include="Monai.Deploy.Storage" Version="0.2.7" />
     <PackageReference Include="System.IO.Abstractions" Version="17.2.3" />
   </ItemGroup>
 

--- a/src/Configuration/StorageConfiguration.cs
+++ b/src/Configuration/StorageConfiguration.cs
@@ -26,7 +26,7 @@ namespace Monai.Deploy.InformaticsGateway.Configuration
         /// Gets or sets whether to store temporary data in <c>Memory</c> or on <c>Disk</c>.
         /// Defaults to <c>Memory</c>.
         /// </summary>
-        [ConfigurationKeyName("bufferRootPath")]
+        [ConfigurationKeyName("tempStorageLocation")]
         public TemporaryDataStorageLocation TemporaryDataStorage { get; set; } = TemporaryDataStorageLocation.Memory;
 
         /// <summary>

--- a/src/Configuration/StorageConfiguration.cs
+++ b/src/Configuration/StorageConfiguration.cs
@@ -23,11 +23,26 @@ namespace Monai.Deploy.InformaticsGateway.Configuration
     public class StorageConfiguration : StorageServiceConfiguration
     {
         /// <summary>
+        /// Gets or sets whether to store temporary data in <c>Memory</c> or on <c>Disk</c>.
+        /// Defaults to <c>Memory</c>.
+        /// </summary>
+        [ConfigurationKeyName("bufferRootPath")]
+        public TemporaryDataStorageLocation TemporaryDataStorage { get; set; } = TemporaryDataStorageLocation.Memory;
+
+        /// <summary>
         /// Gets or sets the path used for buffering incoming data.
         /// Defaults to <c>./temp</c>.
         /// </summary>
         [ConfigurationKeyName("bufferRootPath")]
         public string BufferStorageRootPath { get; set; } = "./temp";
+
+        /// <summary>
+        /// Gets or sets the number of bytes buffered for reads and writes to the temporary file.
+        /// Defaults to <c>128000</c>.
+        /// </summary>
+        [ConfigurationKeyName("bufferSize")]
+        public int BufferSize { get; set; } = 128000;
+
 
         /// <summary>
         /// Gets or set the maximum memory buffer size in bytes with default to 30MiB.

--- a/src/Configuration/StorageConfiguration.cs
+++ b/src/Configuration/StorageConfiguration.cs
@@ -27,7 +27,7 @@ namespace Monai.Deploy.InformaticsGateway.Configuration
         /// Defaults to <c>Memory</c>.
         /// </summary>
         [ConfigurationKeyName("tempStorageLocation")]
-        public TemporaryDataStorageLocation TemporaryDataStorage { get; set; } = TemporaryDataStorageLocation.Memory;
+        public TemporaryDataStorageLocation TemporaryDataStorage { get; set; } = TemporaryDataStorageLocation.Disk;
 
         /// <summary>
         /// Gets or sets the path used for buffering incoming data.

--- a/src/Configuration/TemporaryDataStorageLocation.cs
+++ b/src/Configuration/TemporaryDataStorageLocation.cs
@@ -1,0 +1,24 @@
+﻿/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Monai.Deploy.InformaticsGateway.Configuration
+{
+    public enum TemporaryDataStorageLocation
+    {
+        Memory,
+        Disk
+    }
+}

--- a/src/Configuration/Test/ConfigurationValidatorTest.cs
+++ b/src/Configuration/Test/ConfigurationValidatorTest.cs
@@ -15,6 +15,8 @@
  */
 
 using System;
+using System.IO;
+using System.IO.Abstractions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Monai.Deploy.InformaticsGateway.SharedTest;
@@ -26,17 +28,19 @@ namespace Monai.Deploy.InformaticsGateway.Configuration.Test
     public class ConfigurationValidatorTest
     {
         private readonly Mock<ILogger<ConfigurationValidator>> _logger;
+        private readonly Mock<IFileSystem> _fileSystem;
 
         public ConfigurationValidatorTest()
         {
             _logger = new Mock<ILogger<ConfigurationValidator>>();
+            _fileSystem = new Mock<IFileSystem>();
         }
 
         [Fact(DisplayName = "ConfigurationValidator test with all valid settings")]
         public void AllValid()
         {
             var config = MockValidConfiguration();
-            var valid = new ConfigurationValidator(_logger.Object).Validate("", config);
+            var valid = new ConfigurationValidator(_logger.Object, _fileSystem.Object).Validate("", config);
             Assert.True(valid == ValidateOptionsResult.Success);
         }
 
@@ -46,7 +50,7 @@ namespace Monai.Deploy.InformaticsGateway.Configuration.Test
             var config = MockValidConfiguration();
             config.Dicom.Scp.Port = Int32.MaxValue;
 
-            var valid = new ConfigurationValidator(_logger.Object).Validate("", config);
+            var valid = new ConfigurationValidator(_logger.Object, _fileSystem.Object).Validate("", config);
 
             var validationMessage = $"Invalid port number '{Int32.MaxValue}' specified for InformaticsGateway>dicom>scp>port.";
             Assert.Equal(validationMessage, valid.FailureMessage);
@@ -59,7 +63,7 @@ namespace Monai.Deploy.InformaticsGateway.Configuration.Test
             var config = MockValidConfiguration();
             config.Dicom.Scp.MaximumNumberOfAssociations = 0;
 
-            var valid = new ConfigurationValidator(_logger.Object).Validate("", config);
+            var valid = new ConfigurationValidator(_logger.Object, _fileSystem.Object).Validate("", config);
 
             var validationMessage = $"Value of InformaticsGateway>dicom>scp>max-associations must be between {1} and {1000}.";
             Assert.Equal(validationMessage, valid.FailureMessage);
@@ -72,7 +76,7 @@ namespace Monai.Deploy.InformaticsGateway.Configuration.Test
             var config = MockValidConfiguration();
             config.Storage.Watermark = 1000;
 
-            var valid = new ConfigurationValidator(_logger.Object).Validate("", config);
+            var valid = new ConfigurationValidator(_logger.Object, _fileSystem.Object).Validate("", config);
 
             var validationMessage = "Value of InformaticsGateway>storage>watermark must be between 1 and 100.";
             Assert.Equal(validationMessage, valid.FailureMessage);
@@ -85,7 +89,7 @@ namespace Monai.Deploy.InformaticsGateway.Configuration.Test
             var config = MockValidConfiguration();
             config.Storage.ReserveSpaceGB = 9999;
 
-            var valid = new ConfigurationValidator(_logger.Object).Validate("", config);
+            var valid = new ConfigurationValidator(_logger.Object, _fileSystem.Object).Validate("", config);
 
             var validationMessage = "Value of InformaticsGateway>storage>reserveSpaceGB must be between 1 and 999.";
             Assert.Equal(validationMessage, valid.FailureMessage);
@@ -98,7 +102,7 @@ namespace Monai.Deploy.InformaticsGateway.Configuration.Test
             var config = MockValidConfiguration();
             config.Storage.TemporaryStorageBucket = " ";
 
-            var valid = new ConfigurationValidator(_logger.Object).Validate("", config);
+            var valid = new ConfigurationValidator(_logger.Object, _fileSystem.Object).Validate("", config);
 
             var validationMessages = new[] { "Value for InformaticsGateway>storage>temporaryBucketName is required.", "Value for InformaticsGateway>storage>temporaryBucketName does not conform to Amazon S3 bucket naming requirements." };
             Assert.Equal(string.Join(Environment.NewLine, validationMessages), valid.FailureMessage);
@@ -114,9 +118,29 @@ namespace Monai.Deploy.InformaticsGateway.Configuration.Test
             var config = MockValidConfiguration();
             config.Storage.StorageServiceBucketName = "";
 
-            var valid = new ConfigurationValidator(_logger.Object).Validate("", config);
+            var valid = new ConfigurationValidator(_logger.Object, _fileSystem.Object).Validate("", config);
 
             var validationMessages = new[] { "Value for InformaticsGateway>storage>bucketName is required.", "Value for InformaticsGateway>storage>bucketName does not conform to Amazon S3 bucket naming requirements." };
+            Assert.Equal(string.Join(Environment.NewLine, validationMessages), valid.FailureMessage);
+            foreach (var message in validationMessages)
+            {
+                _logger.VerifyLogging(message, LogLevel.Error, Times.Once());
+            }
+        }
+
+        [Fact(DisplayName = "ConfigurationValidator test with inaccessible directory")]
+        public void StorageWithInaccessbleDirectory()
+        {
+            _fileSystem.Setup(p => p.Directory.Exists(It.IsAny<string>())).Returns(true);
+            _fileSystem.Setup(p => p.File.Create(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<FileOptions>())).Throws(new UnauthorizedAccessException("error"));
+
+            var config = MockValidConfiguration();
+            config.Storage.TemporaryDataStorage = TemporaryDataStorageLocation.Disk;
+            config.Storage.BufferStorageRootPath = "/blabla";
+
+            var valid = new ConfigurationValidator(_logger.Object, _fileSystem.Object).Validate("", config);
+
+            var validationMessages = new[] { $"Directory `/blabla` specified in `InformaticsGateway>storage>bufferRootPath` is not accessible: error." };
             Assert.Equal(string.Join(Environment.NewLine, validationMessages), valid.FailureMessage);
             foreach (var message in validationMessages)
             {

--- a/src/Configuration/Test/ConfigurationValidatorTest.cs
+++ b/src/Configuration/Test/ConfigurationValidatorTest.cs
@@ -34,6 +34,8 @@ namespace Monai.Deploy.InformaticsGateway.Configuration.Test
         {
             _logger = new Mock<ILogger<ConfigurationValidator>>();
             _fileSystem = new Mock<IFileSystem>();
+            _fileSystem.Setup(p => p.Directory.Exists(It.IsAny<string>())).Returns(true);
+            _fileSystem.Setup(p => p.File.Create(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<FileOptions>())).Returns(FileStream.Null);
         }
 
         [Fact(DisplayName = "ConfigurationValidator test with all valid settings")]
@@ -131,7 +133,6 @@ namespace Monai.Deploy.InformaticsGateway.Configuration.Test
         [Fact(DisplayName = "ConfigurationValidator test with inaccessible directory")]
         public void StorageWithInaccessbleDirectory()
         {
-            _fileSystem.Setup(p => p.Directory.Exists(It.IsAny<string>())).Returns(true);
             _fileSystem.Setup(p => p.File.Create(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<FileOptions>())).Throws(new UnauthorizedAccessException("error"));
 
             var config = MockValidConfiguration();

--- a/src/Database/PayloadConfiguration.cs
+++ b/src/Database/PayloadConfiguration.cs
@@ -57,6 +57,7 @@ namespace Monai.Deploy.InformaticsGateway.Database
             builder.Ignore(j => j.CalledAeTitle);
             builder.Ignore(j => j.CallingAeTitle);
             builder.Ignore(j => j.HasTimedOut);
+            builder.Ignore(j => j.Elapsed);
             builder.Ignore(j => j.Count);
         }
     }

--- a/src/InformaticsGateway/Common/FileStorageMetadataExtensions.cs
+++ b/src/InformaticsGateway/Common/FileStorageMetadataExtensions.cs
@@ -14,41 +14,92 @@
  * limitations under the License.
  */
 
-using System.IO;
+using System.IO.Abstractions;
 using System.Text;
 using System.Threading.Tasks;
 using Ardalis.GuardClauses;
 using FellowOakDicom;
 using Monai.Deploy.InformaticsGateway.Api.Storage;
+using Monai.Deploy.InformaticsGateway.Configuration;
 
 namespace Monai.Deploy.InformaticsGateway.Common
 {
     internal static class FileStorageMetadataExtensions
     {
-        public static async Task SetDataStreams(this DicomFileStorageMetadata dicomFileStorageMetadata, DicomFile dicomFile, string dicomJson)
+        public static async Task SetDataStreams(
+            this DicomFileStorageMetadata dicomFileStorageMetadata,
+            DicomFile dicomFile,
+            string dicomJson,
+            TemporaryDataStorageLocation storageLocation,
+            IFileSystem fileSystem = null,
+            string temporaryStoragePath = "")
         {
             Guard.Against.Null(dicomFile, nameof(dicomFile));
             Guard.Against.Null(dicomJson, nameof(dicomJson)); // allow empty here
 
-            dicomFileStorageMetadata.File.Data = new MemoryStream();
-            await dicomFile.SaveAsync(dicomFileStorageMetadata.File.Data).ConfigureAwait(false);
-            dicomFileStorageMetadata.File.Data.Seek(0, SeekOrigin.Begin);
+            switch (storageLocation)
+            {
+                case TemporaryDataStorageLocation.Disk:
+                    Guard.Against.Null(fileSystem, nameof(fileSystem));
+                    Guard.Against.NullOrWhiteSpace(temporaryStoragePath, nameof(temporaryStoragePath));
 
-            SetTextStream(dicomFileStorageMetadata.JsonFile, dicomJson);
+                    var tempFile = fileSystem.Path.Combine(temporaryStoragePath, $@"{System.DateTime.UtcNow.Ticks}.tmp");
+                    dicomFileStorageMetadata.File.Data = fileSystem.File.Create(tempFile);
+                    break;
+                default:
+                    dicomFileStorageMetadata.File.Data = new System.IO.MemoryStream();
+                    break;
+            }
+
+            await dicomFile.SaveAsync(dicomFileStorageMetadata.File.Data).ConfigureAwait(false);
+            dicomFileStorageMetadata.File.Data.Seek(0, System.IO.SeekOrigin.Begin);
+
+            await SetTextStream(dicomFileStorageMetadata.JsonFile, dicomJson, storageLocation, fileSystem, temporaryStoragePath);
         }
 
-        public static void SetDataStream(this FhirFileStorageMetadata fhirFileStorageMetadata, string json)
-            => SetTextStream(fhirFileStorageMetadata.File, json);
+        public static async Task SetDataStream(
+            this FhirFileStorageMetadata fhirFileStorageMetadata,
+            string json,
+            TemporaryDataStorageLocation storageLocation,
+            IFileSystem fileSystem = null,
+            string temporaryStoragePath = "")
+            => await SetTextStream(fhirFileStorageMetadata.File, json, storageLocation, fileSystem, temporaryStoragePath);
 
-        public static void SetDataStream(this Hl7FileStorageMetadata hl7FileStorageMetadata, string message)
-            => SetTextStream(hl7FileStorageMetadata.File, message);
+        public static async Task SetDataStream(
+            this Hl7FileStorageMetadata hl7FileStorageMetadata,
+             string message,
+             TemporaryDataStorageLocation storageLocation,
+            IFileSystem fileSystem = null,
+             string temporaryStoragePath = "")
+            => await SetTextStream(hl7FileStorageMetadata.File, message, storageLocation, fileSystem, temporaryStoragePath);
 
-        private static void SetTextStream(StorageObjectMetadata storageObjectMetadata, string message)
+        private static async Task SetTextStream(
+            StorageObjectMetadata storageObjectMetadata,
+            string message,
+            TemporaryDataStorageLocation storageLocation,
+            IFileSystem fileSystem = null,
+            string temporaryStoragePath = "")
         {
             Guard.Against.Null(message, nameof(message)); // allow empty here
 
-            storageObjectMetadata.Data = new MemoryStream(Encoding.UTF8.GetBytes(message));
-            storageObjectMetadata.Data.Seek(0, SeekOrigin.Begin);
+            switch (storageLocation)
+            {
+                case TemporaryDataStorageLocation.Disk:
+                    Guard.Against.Null(fileSystem, nameof(fileSystem));
+                    Guard.Against.NullOrWhiteSpace(temporaryStoragePath, nameof(temporaryStoragePath));
+
+                    var tempFile = fileSystem.Path.Combine(temporaryStoragePath, $@"{System.DateTime.UtcNow.Ticks}.tmp");
+                    var stream = fileSystem.File.Create(tempFile);
+                    var data = Encoding.UTF8.GetBytes(message);
+                    await stream.WriteAsync(data, 0, data.Length);
+                    storageObjectMetadata.Data = stream;
+                    break;
+                default:
+                    storageObjectMetadata.Data = new System.IO.MemoryStream(Encoding.UTF8.GetBytes(message));
+                    break;
+            }
+
+            storageObjectMetadata.Data.Seek(0, System.IO.SeekOrigin.Begin);
         }
     }
 }

--- a/src/InformaticsGateway/Common/FileStorageMetadataExtensions.cs
+++ b/src/InformaticsGateway/Common/FileStorageMetadataExtensions.cs
@@ -43,7 +43,7 @@ namespace Monai.Deploy.InformaticsGateway.Common
                     Guard.Against.Null(fileSystem, nameof(fileSystem));
                     Guard.Against.NullOrWhiteSpace(temporaryStoragePath, nameof(temporaryStoragePath));
 
-                    var tempFile = fileSystem.Path.Combine(temporaryStoragePath, $@"{System.DateTime.UtcNow.Ticks}.tmp");
+                    var tempFile = fileSystem.Path.Combine(temporaryStoragePath, $@"{fileSystem.Path.GetRandomFileName()}");
                     dicomFileStorageMetadata.File.Data = fileSystem.File.Create(tempFile);
                     break;
                 default:
@@ -88,7 +88,7 @@ namespace Monai.Deploy.InformaticsGateway.Common
                     Guard.Against.Null(fileSystem, nameof(fileSystem));
                     Guard.Against.NullOrWhiteSpace(temporaryStoragePath, nameof(temporaryStoragePath));
 
-                    var tempFile = fileSystem.Path.Combine(temporaryStoragePath, $@"{System.DateTime.UtcNow.Ticks}.tmp");
+                    var tempFile = fileSystem.Path.Combine(temporaryStoragePath, $@"{fileSystem.Path.GetRandomFileName()}");
                     var stream = fileSystem.File.Create(tempFile);
                     var data = Encoding.UTF8.GetBytes(message);
                     await stream.WriteAsync(data, 0, data.Length);

--- a/src/InformaticsGateway/Logging/Log.700.PayloadService.cs
+++ b/src/InformaticsGateway/Logging/Log.700.PayloadService.cs
@@ -53,8 +53,8 @@ namespace Monai.Deploy.InformaticsGateway.Logging
         [LoggerMessage(EventId = 711, Level = LogLevel.Information, Message = "Publishing workflow request message ID={messageId}...")]
         public static partial void PublishingWorkflowRequest(this ILogger logger, string messageId);
 
-        [LoggerMessage(EventId = 712, Level = LogLevel.Information, Message = "Workflow request published to {queue}, message ID={messageId}.")]
-        public static partial void WorkflowRequestPublished(this ILogger logger, string queue, string messageId);
+        [LoggerMessage(EventId = 712, Level = LogLevel.Information, Message = "Workflow request published to {queue}, message ID={messageId}. Payload took {payloadElapsedTime} to complete.")]
+        public static partial void WorkflowRequestPublished(this ILogger logger, string queue, string messageId, TimeSpan payloadElapsedTime);
 
         [LoggerMessage(EventId = 713, Level = LogLevel.Information, Message = "Restoring payloads from database.")]
         public static partial void StartupRestoreFromDatabase(this ILogger logger);

--- a/src/InformaticsGateway/Monai.Deploy.InformaticsGateway.csproj
+++ b/src/InformaticsGateway/Monai.Deploy.InformaticsGateway.csproj
@@ -47,9 +47,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.4" />
-    <PackageReference Include="Monai.Deploy.Storage" Version="0.2.5" />
-    <PackageReference Include="Monai.Deploy.Storage.MinIO" Version="0.2.5" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.5" />
+    <PackageReference Include="Monai.Deploy.Storage" Version="0.2.7" />
+    <PackageReference Include="Monai.Deploy.Storage.MinIO" Version="0.2.7" />
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>

--- a/src/InformaticsGateway/Services/Connectors/PayloadNotificationActionHandler.cs
+++ b/src/InformaticsGateway/Services/Connectors/PayloadNotificationActionHandler.cs
@@ -138,7 +138,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Connectors
                 _options.Value.Messaging.Topics.WorkflowRequest,
                 message.ToMessage()).ConfigureAwait(false);
 
-            _logger.WorkflowRequestPublished(_options.Value.Messaging.Topics.WorkflowRequest, message.MessageId);
+            _logger.WorkflowRequestPublished(_options.Value.Messaging.Topics.WorkflowRequest, message.MessageId, payload.Elapsed);
         }
 
         private async Task<PayloadAction> UpdatePayloadState(Payload payload)

--- a/src/InformaticsGateway/Services/DicomWeb/IStreamsWriter.cs
+++ b/src/InformaticsGateway/Services/DicomWeb/IStreamsWriter.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions;
 using System.Threading;
 using System.Threading.Tasks;
 using Ardalis.GuardClauses;
@@ -43,6 +44,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.DicomWeb
     internal class StreamsWriter : IStreamsWriter
     {
         private readonly ILogger<StreamsWriter> _logger;
+        private readonly IFileSystem _fileSystem;
         private readonly IObjectUploadQueue _uploadQueue;
         private readonly IDicomToolkit _dicomToolkit;
         private readonly IPayloadAssembler _payloadAssembler;
@@ -56,13 +58,15 @@ namespace Monai.Deploy.InformaticsGateway.Services.DicomWeb
             IDicomToolkit dicomToolkit,
             IPayloadAssembler payloadAssembler,
             IOptions<InformaticsGatewayConfiguration> configuration,
-            ILogger<StreamsWriter> logger)
+            ILogger<StreamsWriter> logger,
+            IFileSystem fileSystem)
         {
             _uploadQueue = fileStore ?? throw new ArgumentNullException(nameof(fileStore));
             _dicomToolkit = dicomToolkit ?? throw new ArgumentNullException(nameof(dicomToolkit));
             _payloadAssembler = payloadAssembler ?? throw new ArgumentNullException(nameof(payloadAssembler));
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
             _resultDicomDataset = new DicomDataset();
             _failureCount = 0;
             _storedCount = 0;
@@ -165,7 +169,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.DicomWeb
                 dicomInfo.SetWorkflows(workflowName);
             }
 
-            await dicomInfo.SetDataStreams(dicomFile, dicomFile.ToJson(_configuration.Value.Dicom.WriteDicomJson, _configuration.Value.Dicom.ValidateDicomOnSerialization)).ConfigureAwait(false);
+            await dicomInfo.SetDataStreams(dicomFile, dicomFile.ToJson(_configuration.Value.Dicom.WriteDicomJson, _configuration.Value.Dicom.ValidateDicomOnSerialization), _configuration.Value.Storage.TemporaryDataStorage, _fileSystem, _configuration.Value.Storage.BufferStorageRootPath).ConfigureAwait(false);
             _uploadQueue.Queue(dicomInfo);
 
             // for DICOMweb, use correlation ID as the grouping key

--- a/src/InformaticsGateway/Services/Fhir/FhirJsonReader.cs
+++ b/src/InformaticsGateway/Services/Fhir/FhirJsonReader.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.IO;
+using System.IO.Abstractions;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading;
@@ -23,9 +24,11 @@ using System.Threading.Tasks;
 using Ardalis.GuardClauses;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 using Monai.Deploy.InformaticsGateway.Api.Storage;
 using Monai.Deploy.InformaticsGateway.Common;
+using Monai.Deploy.InformaticsGateway.Configuration;
 using Monai.Deploy.InformaticsGateway.Logging;
 
 namespace Monai.Deploy.InformaticsGateway.Services.Fhir
@@ -33,10 +36,14 @@ namespace Monai.Deploy.InformaticsGateway.Services.Fhir
     internal class FhirJsonReader : IFHirRequestReader
     {
         private readonly ILogger<FhirJsonReader> _logger;
+        private readonly IOptions<InformaticsGatewayConfiguration> _options;
+        private readonly IFileSystem _fileSystem;
 
-        public FhirJsonReader(ILogger<FhirJsonReader> logger)
+        public FhirJsonReader(ILogger<FhirJsonReader> logger, IOptions<InformaticsGatewayConfiguration> options, IFileSystem fileSystem)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
         }
 
         public async Task<FhirStoreResult> GetContentAsync(HttpRequest request, string correlationId, string resourceType, MediaTypeHeaderValue mediaTypeHeaderValue, CancellationToken cancellationToken)
@@ -68,7 +75,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Fhir
             result.RawData = jsonDoc.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
 
             var fileMetadata = new FhirFileStorageMetadata(correlationId, result.InternalResourceType, resourceId, Api.Rest.FhirStorageFormat.Json);
-            fileMetadata.SetDataStream(result.RawData);
+            await fileMetadata.SetDataStream(result.RawData, _options.Value.Storage.TemporaryDataStorage, _fileSystem, _options.Value.Storage.BufferStorageRootPath);
 
             result.Metadata = fileMetadata;
             return result;

--- a/src/InformaticsGateway/Services/Fhir/FhirService.cs
+++ b/src/InformaticsGateway/Services/Fhir/FhirService.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.IO.Abstractions;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -41,6 +42,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Fhir
         private readonly ILogger<FhirService> _logger;
         private readonly IPayloadAssembler _payloadAssembler;
         private readonly IObjectUploadQueue _uploadQueue;
+        private readonly IFileSystem _fileSystem;
 
         public FhirService(IServiceScopeFactory serviceScopeFactory, IOptions<InformaticsGatewayConfiguration> configuration)
         {
@@ -51,6 +53,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Fhir
             _logger = scope.ServiceProvider.GetService<ILogger<FhirService>>() ?? throw new ServiceNotFoundException(nameof(ILogger<FhirService>));
             _payloadAssembler = scope.ServiceProvider.GetService<IPayloadAssembler>() ?? throw new ServiceNotFoundException(nameof(IPayloadAssembler));
             _uploadQueue = scope.ServiceProvider.GetService<IObjectUploadQueue>() ?? throw new ServiceNotFoundException(nameof(IObjectUploadQueue));
+            _fileSystem = scope.ServiceProvider.GetService<IFileSystem>() ?? throw new ServiceNotFoundException(nameof(IFileSystem));
         }
 
         public async Task<FhirStoreResult> StoreAsync(HttpRequest request, string correlationId, string resourceType, CancellationToken cancellationToken)
@@ -100,13 +103,13 @@ namespace Monai.Deploy.InformaticsGateway.Services.Fhir
             if (mediaTypeHeaderValue.MediaType.Equals(ContentTypes.ApplicationFhirJson, StringComparison.OrdinalIgnoreCase))
             {
                 var logger = scope.ServiceProvider.GetService<ILogger<FhirJsonReader>>() ?? throw new ServiceNotFoundException(nameof(ILogger<FhirJsonReader>));
-                return new FhirJsonReader(logger);
+                return new FhirJsonReader(logger, _configuration, _fileSystem);
             }
 
             if (mediaTypeHeaderValue.MediaType.Equals(ContentTypes.ApplicationFhirXml, StringComparison.OrdinalIgnoreCase))
             {
                 var logger = scope.ServiceProvider.GetService<ILogger<FhirXmlReader>>() ?? throw new ServiceNotFoundException(nameof(ILogger<FhirXmlReader>));
-                return new FhirXmlReader(logger);
+                return new FhirXmlReader(logger, _configuration, _fileSystem);
             }
 
             throw new UnsupportedContentTypeException($"Media type of '{mediaTypeHeaderValue.MediaType}' is not supported.");

--- a/src/InformaticsGateway/Services/Fhir/FhirXmlReader.cs
+++ b/src/InformaticsGateway/Services/Fhir/FhirXmlReader.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.IO;
+using System.IO.Abstractions;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,9 +24,11 @@ using System.Xml;
 using Ardalis.GuardClauses;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 using Monai.Deploy.InformaticsGateway.Api.Storage;
 using Monai.Deploy.InformaticsGateway.Common;
+using Monai.Deploy.InformaticsGateway.Configuration;
 using Monai.Deploy.InformaticsGateway.Logging;
 
 namespace Monai.Deploy.InformaticsGateway.Services.Fhir
@@ -33,10 +36,14 @@ namespace Monai.Deploy.InformaticsGateway.Services.Fhir
     internal class FhirXmlReader : IFHirRequestReader
     {
         private readonly ILogger<FhirXmlReader> _logger;
+        private readonly IOptions<InformaticsGatewayConfiguration> _options;
+        private readonly IFileSystem _fileSystem;
 
-        public FhirXmlReader(ILogger<FhirXmlReader> logger)
+        public FhirXmlReader(ILogger<FhirXmlReader> logger, IOptions<InformaticsGatewayConfiguration> options, IFileSystem fileSystem)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
         }
 
         public async Task<FhirStoreResult> GetContentAsync(HttpRequest request, string correlationId, string resourceType, MediaTypeHeaderValue mediaTypeHeaderValue, CancellationToken cancellationToken)
@@ -80,7 +87,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Fhir
             result.InternalResourceType = rootNode.Name;
 
             var fileMetadata = new FhirFileStorageMetadata(correlationId, result.InternalResourceType, resourceId, Api.Rest.FhirStorageFormat.Xml);
-            fileMetadata.SetDataStream(result.RawData);
+            await fileMetadata.SetDataStream(result.RawData, _options.Value.Storage.TemporaryDataStorage, _fileSystem, _options.Value.Storage.BufferStorageRootPath);
 
             result.Metadata = fileMetadata;
             return result;

--- a/src/InformaticsGateway/Services/Http/MonaiHealthCheck.cs
+++ b/src/InformaticsGateway/Services/Http/MonaiHealthCheck.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -41,23 +40,14 @@ namespace Monai.Deploy.InformaticsGateway.Services.Http
             {
                 return Task.FromResult(HealthCheckResult.Healthy());
             }
+            var unhealthyServices = services.Where(item => item.Value != Api.Rest.ServiceStatus.Running).ToDictionary(k => k.Key, v => (object)v.Value);
 
-            if (services.Values.All(p => p == Api.Rest.ServiceStatus.Stopped ||
-                                            p == Api.Rest.ServiceStatus.Cancelled ||
-                                            p == Api.Rest.ServiceStatus.Unknown))
+            if (unhealthyServices.Count == services.Count)
             {
-                return Task.FromResult(HealthCheckResult.Unhealthy());
+                return Task.FromResult(HealthCheckResult.Unhealthy(data: unhealthyServices));
             }
 
-            var sb = new StringBuilder();
-            foreach (var service in services.Keys)
-            {
-                if (services[service] != Api.Rest.ServiceStatus.Running)
-                {
-                    sb.AppendLine($"{service}: {services[service]}");
-                }
-            }
-            return Task.FromResult(HealthCheckResult.Degraded(sb.ToString()));
+            return Task.FromResult(HealthCheckResult.Degraded(data: unhealthyServices));
         }
     }
 }

--- a/src/InformaticsGateway/Services/Scp/ApplicationEntityHandler.cs
+++ b/src/InformaticsGateway/Services/Scp/ApplicationEntityHandler.cs
@@ -15,12 +15,14 @@
  */
 
 using System;
+using System.IO.Abstractions;
 using System.Linq;
 using System.Threading.Tasks;
 using Ardalis.GuardClauses;
 using FellowOakDicom.Network;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Monai.Deploy.InformaticsGateway.Api;
 using Monai.Deploy.InformaticsGateway.Api.Storage;
 using Monai.Deploy.InformaticsGateway.Common;
@@ -34,11 +36,12 @@ namespace Monai.Deploy.InformaticsGateway.Services.Scp
     internal class ApplicationEntityHandler : IDisposable, IApplicationEntityHandler
     {
         private readonly ILogger<ApplicationEntityHandler> _logger;
+        private readonly IOptions<InformaticsGatewayConfiguration> _options;
 
         private readonly IServiceScope _serviceScope;
         private readonly IPayloadAssembler _payloadAssembler;
         private readonly IObjectUploadQueue _uploadQueue;
-
+        private readonly IFileSystem _fileSystem;
         private MonaiApplicationEntity _configuration;
         private DicomJsonOptions _dicomJsonOptions;
         private bool _validateDicomValueOnJsonSerialization;
@@ -46,14 +49,17 @@ namespace Monai.Deploy.InformaticsGateway.Services.Scp
 
         public ApplicationEntityHandler(
             IServiceScopeFactory serviceScopeFactory,
-            ILogger<ApplicationEntityHandler> logger)
+            ILogger<ApplicationEntityHandler> logger,
+            IOptions<InformaticsGatewayConfiguration> options)
         {
             Guard.Against.Null(serviceScopeFactory, nameof(serviceScopeFactory));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
 
             _serviceScope = serviceScopeFactory.CreateScope();
             _payloadAssembler = _serviceScope.ServiceProvider.GetService<IPayloadAssembler>() ?? throw new ServiceNotFoundException(nameof(IPayloadAssembler));
             _uploadQueue = _serviceScope.ServiceProvider.GetService<IObjectUploadQueue>() ?? throw new ServiceNotFoundException(nameof(IObjectUploadQueue));
+            _fileSystem = _serviceScope.ServiceProvider.GetService<IFileSystem>() ?? throw new ServiceNotFoundException(nameof(IFileSystem));
         }
 
         public void Configure(MonaiApplicationEntity monaiApplicationEntity, DicomJsonOptions dicomJsonOptions, bool validateDicomValuesOnJsonSerialization)
@@ -95,7 +101,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Scp
                 dicomInfo.SetWorkflows(_configuration.Workflows.ToArray());
             }
 
-            await dicomInfo.SetDataStreams(request.File, request.File.ToJson(_dicomJsonOptions, _validateDicomValueOnJsonSerialization)).ConfigureAwait(false);
+            await dicomInfo.SetDataStreams(request.File, request.File.ToJson(_dicomJsonOptions, _validateDicomValueOnJsonSerialization), _options.Value.Storage.TemporaryDataStorage, _fileSystem, _options.Value.Storage.BufferStorageRootPath).ConfigureAwait(false);
             _uploadQueue.Queue(dicomInfo);
 
             var dicomTag = FellowOakDicom.DicomTag.Parse(_configuration.Grouping);

--- a/src/InformaticsGateway/Test/Common/DicomFileStorageMetadataExtensionsTest.cs
+++ b/src/InformaticsGateway/Test/Common/DicomFileStorageMetadataExtensionsTest.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.IO;
+using System.IO.Abstractions.TestingHelpers;
 using System.Text;
 using System.Threading.Tasks;
 using FellowOakDicom;
@@ -31,7 +32,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Common
     public class DicomFileStorageMetadataExtensionsTest
     {
         [Fact]
-        public async Task GivenADicomFileStorageMetadata_WhenSetDataStreamsIsCalled_ExpectDataStreamsAreSet()
+        public async Task GivenADicomFileStorageMetadata_WhenSetDataStreamsIsCalledWithInMemoryStore_ExpectDataStreamsAreSet()
         {
             var metadata = new DicomFileStorageMetadata(
                 Guid.NewGuid().ToString(),
@@ -42,7 +43,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Common
 
             var dicom = InstanceGenerator.GenerateDicomFile();
             var json = dicom.ToJson(DicomJsonOptions.Complete, false);
-            await metadata.SetDataStreams(dicom, json).ConfigureAwait(false);
+            await metadata.SetDataStreams(dicom, json, TemporaryDataStorageLocation.Memory).ConfigureAwait(false);
 
             Assert.NotNull(metadata.File.Data);
             Assert.NotNull(metadata.JsonFile.Data);
@@ -59,7 +60,38 @@ namespace Monai.Deploy.InformaticsGateway.Test.Common
         }
 
         [Fact]
-        public async Task GivenADicomFileStorageMetadataWithInvalidDSValue_WhenSetDataStreamsIsCalledWithValidation_ThrowsFormatException()
+        public async Task GivenADicomFileStorageMetadata_WhenSetDataStreamsIsCalledWithDiskStore_ExpectDataStreamsAreSet()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory("/temp");
+
+            var metadata = new DicomFileStorageMetadata(
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString());
+
+            var dicom = InstanceGenerator.GenerateDicomFile();
+            var json = dicom.ToJson(DicomJsonOptions.Complete, false);
+            await metadata.SetDataStreams(dicom, json, TemporaryDataStorageLocation.Disk, fileSystem, "/temp").ConfigureAwait(false);
+
+            Assert.NotNull(metadata.File.Data);
+            Assert.NotNull(metadata.JsonFile.Data);
+
+            var ms = new MemoryStream();
+            await dicom.SaveAsync(ms).ConfigureAwait(false);
+            Assert.Equal(ms.ToArray(), (metadata.File.Data as MemoryStream).ToArray());
+
+            var jsonFromStream = Encoding.UTF8.GetString((metadata.JsonFile.Data as MemoryStream).ToArray());
+            Assert.Equal(json.Trim(), jsonFromStream.Trim());
+
+            var dicomFileFromJson = DicomJson.ConvertJsonToDicom(json);
+            Assert.Equal(dicom.Dataset, dicomFileFromJson);
+        }
+
+        [Fact]
+        public void GivenADicomFileStorageMetadataWithInvalidDSValue_WhenSetDataStreamsIsCalledWithValidation_ThrowsFormatException()
         {
             var metadata = new DicomFileStorageMetadata(
                 Guid.NewGuid().ToString(),
@@ -94,7 +126,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Common
             dicom.Dataset.Add(DicomTag.PixelSpacing, "0.68300002813334234392234", "0.2354257587243524352345");
 
             var json = dicom.ToJson(DicomJsonOptions.Complete, false);
-            await metadata.SetDataStreams(dicom, json).ConfigureAwait(false);
+            await metadata.SetDataStreams(dicom, json, TemporaryDataStorageLocation.Memory).ConfigureAwait(false);
 
             Assert.NotNull(metadata.File.Data);
             Assert.NotNull(metadata.JsonFile.Data);

--- a/src/InformaticsGateway/Test/Services/Connectors/DataRetrievalServiceTest.cs
+++ b/src/InformaticsGateway/Test/Services/Connectors/DataRetrievalServiceTest.cs
@@ -100,6 +100,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
             _serviceScope.Setup(p => p.ServiceProvider).Returns(_serviceProvider);
 
             _logger.Setup(p => p.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+            _options.Value.Storage.TemporaryDataStorage = TemporaryDataStorageLocation.Memory;
         }
 
         [RetryFact(5, 250)]

--- a/src/InformaticsGateway/Test/Services/Connectors/DataRetrievalServiceTest.cs
+++ b/src/InformaticsGateway/Test/Services/Connectors/DataRetrievalServiceTest.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
@@ -54,6 +55,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
         private readonly Mock<IObjectUploadQueue> _uploadQueue;
         private readonly Mock<IPayloadAssembler> _payloadAssembler;
         private readonly Mock<IDicomToolkit> _dicomToolkit;
+        private readonly Mock<IFileSystem> _fileSystem;
         private readonly Mock<IInferenceRequestRepository> _inferenceRequestStore;
 
         private readonly Mock<ILogger<DicomWebClient>> _loggerDicomWebClient;
@@ -74,6 +76,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
             _serviceScopeFactory = new Mock<IServiceScopeFactory>();
             _uploadQueue = new Mock<IObjectUploadQueue>();
             _dicomToolkit = new Mock<IDicomToolkit>();
+            _fileSystem = new Mock<IFileSystem>();
             _options = Options.Create(new InformaticsGatewayConfiguration());
             _serviceScope = new Mock<IServiceScope>();
 
@@ -90,6 +93,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Connectors
             services.AddScoped(p => _payloadAssembler.Object);
             services.AddScoped(p => _dicomToolkit.Object);
             services.AddScoped(p => _inferenceRequestStore.Object);
+            services.AddScoped(p => _fileSystem.Object);
 
             _serviceProvider = services.BuildServiceProvider();
             _serviceScopeFactory.Setup(p => p.CreateScope()).Returns(_serviceScope.Object);

--- a/src/InformaticsGateway/Test/Services/DicomWeb/StreamsWriterTest.cs
+++ b/src/InformaticsGateway/Test/Services/DicomWeb/StreamsWriterTest.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions.TestingHelpers;
 using System.Threading.Tasks;
 using FellowOakDicom;
 using FellowOakDicom.Network;
@@ -38,6 +39,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.DicomWeb
     public class StreamsWriterTest
     {
         private readonly Mock<ILogger<StreamsWriter>> _logger;
+        private readonly MockFileSystem _fileSystem;
         private readonly Mock<IObjectUploadQueue> _uploadQueue;
         private readonly Mock<IDicomToolkit> _dicomToolkit;
         private readonly Mock<IPayloadAssembler> _payloadAssembler;
@@ -50,17 +52,19 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.DicomWeb
             _payloadAssembler = new Mock<IPayloadAssembler>();
             _configuration = Options.Create(new InformaticsGatewayConfiguration());
             _logger = new Mock<ILogger<StreamsWriter>>();
+            _fileSystem = new MockFileSystem();
         }
 
         [Fact]
         public void GivenAStreamsWriter_WhenInitialized_ExpectParametersToBeValidated()
         {
-            Assert.Throws<ArgumentNullException>(() => new StreamsWriter(null, null, null, null, null));
-            Assert.Throws<ArgumentNullException>(() => new StreamsWriter(_uploadQueue.Object, null, null, null, null));
-            Assert.Throws<ArgumentNullException>(() => new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, null, null, null));
-            Assert.Throws<ArgumentNullException>(() => new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, null, null));
-            Assert.Throws<ArgumentNullException>(() => new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, _configuration, null));
-            var exception = Record.Exception(() => new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, _configuration, _logger.Object));
+            Assert.Throws<ArgumentNullException>(() => new StreamsWriter(null, null, null, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new StreamsWriter(_uploadQueue.Object, null, null, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, null, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, _configuration, null, null));
+            Assert.Throws<ArgumentNullException>(() => new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, _configuration, _logger.Object, null));
+            var exception = Record.Exception(() => new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, _configuration, _logger.Object, _fileSystem));
 
             Assert.Null(exception);
         }
@@ -72,7 +76,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.DicomWeb
                 .Throws(new Exception("error"));
 
             var studyInstanceUid = DicomUIDGenerator.GenerateDerivedFromUUID().UID;
-            var writer = new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, _configuration, _logger.Object);
+            var writer = new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, _configuration, _logger.Object, _fileSystem);
 
             var streams = GenerateDicomStreams(studyInstanceUid);
             var result = await writer.Save(
@@ -94,7 +98,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.DicomWeb
             _payloadAssembler.Setup(p => p.Queue(It.IsAny<string>(), It.IsAny<DicomFileStorageMetadata>(), It.IsAny<uint>()));
 
             var studyInstanceUid = DicomUIDGenerator.GenerateDerivedFromUUID().UID;
-            var writer = new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, _configuration, _logger.Object);
+            var writer = new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, _configuration, _logger.Object, _fileSystem);
 
             var correlationId = Guid.NewGuid().ToString();
             var streams = GenerateDicomStreams(studyInstanceUid);
@@ -132,7 +136,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.DicomWeb
             _payloadAssembler.Setup(p => p.Queue(It.IsAny<string>(), It.IsAny<DicomFileStorageMetadata>(), It.IsAny<uint>()));
 
             var studyInstanceUid = DicomUIDGenerator.GenerateDerivedFromUUID().UID;
-            var writer = new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, _configuration, _logger.Object);
+            var writer = new StreamsWriter(_uploadQueue.Object, _dicomToolkit.Object, _payloadAssembler.Object, _configuration, _logger.Object, _fileSystem);
 
             var correlationId = Guid.NewGuid().ToString();
             var streams = GenerateDicomStreams(studyInstanceUid);

--- a/src/InformaticsGateway/Test/Services/Fhir/FhirJsonReaderTest.cs
+++ b/src/InformaticsGateway/Test/Services/Fhir/FhirJsonReaderTest.cs
@@ -16,11 +16,14 @@
 
 using System;
 using System.IO;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 using Monai.Deploy.InformaticsGateway.Configuration;
 using Monai.Deploy.InformaticsGateway.Services.Fhir;
@@ -31,13 +34,15 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
 {
     public class FhirJsonReaderTest
     {
-        private readonly InformaticsGatewayConfiguration _config;
         private readonly Mock<ILogger<FhirJsonReader>> _logger;
+        private readonly IOptions<InformaticsGatewayConfiguration> _options;
+        private readonly IFileSystem _fileSystem;
 
         public FhirJsonReaderTest()
         {
-            _config = new InformaticsGatewayConfiguration();
             _logger = new Mock<ILogger<FhirJsonReader>>();
+            _options = Options.Create<InformaticsGatewayConfiguration>(new InformaticsGatewayConfiguration());
+            _fileSystem = new MockFileSystem();
         }
 
         [Fact]
@@ -46,7 +51,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             var request = new Mock<HttpRequest>();
             var correlationId = Guid.NewGuid().ToString();
             var resourceType = "Patient";
-            var reader = new FhirJsonReader(_logger.Object);
+            var reader = new FhirJsonReader(_logger.Object, _options, _fileSystem);
 
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await reader.GetContentAsync(null, null, null, null, CancellationToken.None));
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await reader.GetContentAsync(request.Object, null, null, null, CancellationToken.None));
@@ -62,7 +67,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             var correlationId = Guid.NewGuid().ToString();
             var resourceType = "Patient";
             var contentType = new MediaTypeHeaderValue(ContentTypes.ApplicationFhirJson);
-            var reader = new FhirJsonReader(_logger.Object);
+            var reader = new FhirJsonReader(_logger.Object, _options, _fileSystem);
 
             await Assert.ThrowsAsync<ArgumentNullException>(async () =>
             {
@@ -83,7 +88,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             var correlationId = Guid.NewGuid().ToString();
             var resourceType = "Patient";
             var contentType = new MediaTypeHeaderValue(ContentTypes.ApplicationFhirJson);
-            var reader = new FhirJsonReader(_logger.Object);
+            var reader = new FhirJsonReader(_logger.Object, _options, _fileSystem);
 
             await Assert.ThrowsAnyAsync<JsonException>(async () =>
             {
@@ -106,7 +111,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             var correlationId = Guid.NewGuid().ToString();
             var resourceType = "Patient";
             var contentType = new MediaTypeHeaderValue(ContentTypes.ApplicationFhirJson);
-            var reader = new FhirJsonReader(_logger.Object);
+            var reader = new FhirJsonReader(_logger.Object, _options, _fileSystem);
 
             var data = System.Text.Encoding.UTF8.GetBytes(xml);
             using var stream = new System.IO.MemoryStream();

--- a/src/InformaticsGateway/Test/Services/Fhir/FhirJsonReaderTest.cs
+++ b/src/InformaticsGateway/Test/Services/Fhir/FhirJsonReaderTest.cs
@@ -43,6 +43,8 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             _logger = new Mock<ILogger<FhirJsonReader>>();
             _options = Options.Create<InformaticsGatewayConfiguration>(new InformaticsGatewayConfiguration());
             _fileSystem = new MockFileSystem();
+
+            _options.Value.Storage.TemporaryDataStorage = TemporaryDataStorageLocation.Memory;
         }
 
         [Fact]

--- a/src/InformaticsGateway/Test/Services/Fhir/FhirServiceTest.cs
+++ b/src/InformaticsGateway/Test/Services/Fhir/FhirServiceTest.cs
@@ -82,6 +82,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             _serviceScope.Setup(p => p.ServiceProvider).Returns(_serviceProvider);
 
             _logger.Setup(p => p.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+            _options.Value.Storage.TemporaryDataStorage = TemporaryDataStorageLocation.Memory;
         }
 
         [RetryFact]

--- a/src/InformaticsGateway/Test/Services/Fhir/FhirServiceTest.cs
+++ b/src/InformaticsGateway/Test/Services/Fhir/FhirServiceTest.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.IO;
+using System.IO.Abstractions;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -43,6 +44,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
         private readonly Mock<ILogger<FhirService>> _logger;
         private readonly Mock<ILogger<FhirJsonReader>> _loggerJson;
         private readonly Mock<ILogger<FhirXmlReader>> _loggerXml;
+        private readonly Mock<IFileSystem> _fileSystem;
         private readonly Mock<IPayloadAssembler> _payloadAssembler;
         private readonly Mock<IObjectUploadQueue> _uploadQueue;
 
@@ -62,6 +64,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             _logger = new Mock<ILogger<FhirService>>();
             _loggerJson = new Mock<ILogger<FhirJsonReader>>();
             _loggerXml = new Mock<ILogger<FhirXmlReader>>();
+            _fileSystem = new Mock<IFileSystem>();
 
             _httpRequest = new Mock<HttpRequest>();
 
@@ -73,6 +76,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             services.AddScoped(p => _loggerXml.Object);
             services.AddScoped(p => _uploadQueue.Object);
             services.AddScoped(p => _payloadAssembler.Object);
+            services.AddScoped(p => _fileSystem.Object);
             _serviceProvider = services.BuildServiceProvider();
             _serviceScopeFactory.Setup(p => p.CreateScope()).Returns(_serviceScope.Object);
             _serviceScope.Setup(p => p.ServiceProvider).Returns(_serviceProvider);

--- a/src/InformaticsGateway/Test/Services/Fhir/FhirXmlReaderTest.cs
+++ b/src/InformaticsGateway/Test/Services/Fhir/FhirXmlReaderTest.cs
@@ -43,7 +43,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             _logger = new Mock<ILogger<FhirXmlReader>>();
             _options = Options.Create<InformaticsGatewayConfiguration>(new InformaticsGatewayConfiguration());
             _fileSystem = new MockFileSystem();
-
+            _options.Value.Storage.TemporaryDataStorage = TemporaryDataStorageLocation.Memory;
         }
 
         [Fact]

--- a/src/InformaticsGateway/Test/Services/Fhir/FhirXmlReaderTest.cs
+++ b/src/InformaticsGateway/Test/Services/Fhir/FhirXmlReaderTest.cs
@@ -16,12 +16,16 @@
 
 using System;
 using System.IO;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
+using Monai.Deploy.InformaticsGateway.Configuration;
 using Monai.Deploy.InformaticsGateway.Services.Fhir;
 using Moq;
 using Xunit;
@@ -31,10 +35,15 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
     public class FhirXmlReaderTest
     {
         private readonly Mock<ILogger<FhirXmlReader>> _logger;
+        private readonly IOptions<InformaticsGatewayConfiguration> _options;
+        private readonly IFileSystem _fileSystem;
 
         public FhirXmlReaderTest()
         {
             _logger = new Mock<ILogger<FhirXmlReader>>();
+            _options = Options.Create<InformaticsGatewayConfiguration>(new InformaticsGatewayConfiguration());
+            _fileSystem = new MockFileSystem();
+
         }
 
         [Fact]
@@ -43,7 +52,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             var request = new Mock<HttpRequest>();
             var correlationId = Guid.NewGuid().ToString();
             var resourceType = "Patient";
-            var reader = new FhirXmlReader(_logger.Object);
+            var reader = new FhirXmlReader(_logger.Object, _options, _fileSystem);
 
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await reader.GetContentAsync(null, null, null, null, CancellationToken.None));
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await reader.GetContentAsync(request.Object, null, null, null, CancellationToken.None));
@@ -59,7 +68,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             var correlationId = Guid.NewGuid().ToString();
             var resourceType = "Patient";
             var contentType = new MediaTypeHeaderValue(ContentTypes.ApplicationFhirXml);
-            var reader = new FhirXmlReader(_logger.Object);
+            var reader = new FhirXmlReader(_logger.Object, _options, _fileSystem);
 
             await Assert.ThrowsAsync<ArgumentNullException>(async () =>
             {
@@ -80,7 +89,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             var correlationId = Guid.NewGuid().ToString();
             var resourceType = "Patient";
             var contentType = new MediaTypeHeaderValue(ContentTypes.ApplicationFhirXml);
-            var reader = new FhirXmlReader(_logger.Object);
+            var reader = new FhirXmlReader(_logger.Object, _options, _fileSystem);
 
             await Assert.ThrowsAsync<XmlException>(async () =>
             {
@@ -100,7 +109,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             var correlationId = Guid.NewGuid().ToString();
             var resourceType = "Patient";
             var contentType = new MediaTypeHeaderValue(ContentTypes.ApplicationFhirXml);
-            var reader = new FhirXmlReader(_logger.Object);
+            var reader = new FhirXmlReader(_logger.Object, _options, _fileSystem);
 
             await Assert.ThrowsAsync<FhirStoreException>(async () =>
             {
@@ -123,7 +132,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Fhir
             var correlationId = Guid.NewGuid().ToString();
             var resourceType = "Patient";
             var contentType = new MediaTypeHeaderValue(ContentTypes.ApplicationFhirXml);
-            var reader = new FhirXmlReader(_logger.Object);
+            var reader = new FhirXmlReader(_logger.Object, _options, _fileSystem);
 
             var data = System.Text.Encoding.UTF8.GetBytes(xml);
             using var stream = new System.IO.MemoryStream();

--- a/src/InformaticsGateway/Test/Services/HealthLevel7/MllpServiceTest.cs
+++ b/src/InformaticsGateway/Test/Services/HealthLevel7/MllpServiceTest.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.IO.Abstractions;
 using System.Net;
 using System.Threading;
@@ -83,6 +84,9 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.HealthLevel7
             _serviceProvider = services.BuildServiceProvider();
             _serviceScopeFactory.Setup(p => p.CreateScope()).Returns(_serviceScope.Object);
             _serviceScope.Setup(p => p.ServiceProvider).Returns(_serviceProvider);
+
+            _fileSystem.Setup(p => p.Path.Combine(It.IsAny<string>(), It.IsAny<string>())).Returns((string path1, string path2) => System.IO.Path.Combine(path1, path2));
+            _fileSystem.Setup(p => p.File.Create(It.IsAny<string>())).Returns(FileStream.Null);
 
             _loggerFactory.Setup(p => p.CreateLogger(It.IsAny<string>())).Returns(_logger.Object);
             _tcpListenerFactory.Setup(p => p.CreateTcpListener(It.IsAny<IPAddress>(), It.IsAny<int>())).Returns(_tcpListener.Object);

--- a/src/InformaticsGateway/Test/Services/HealthLevel7/MllpServiceTest.cs
+++ b/src/InformaticsGateway/Test/Services/HealthLevel7/MllpServiceTest.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO.Abstractions;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -47,7 +48,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.HealthLevel7
         private readonly Mock<IObjectUploadQueue> _uploadQueue;
         private readonly Mock<IPayloadAssembler> _payloadAssembler;
         private readonly Mock<ITcpListener> _tcpListener;
-
+        private readonly Mock<IFileSystem> _fileSystem;
         private readonly CancellationTokenSource _cancellationTokenSource;
         private readonly Mock<IServiceScope> _serviceScope;
         private readonly Mock<ILogger<MllpService>> _logger;
@@ -64,6 +65,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.HealthLevel7
             _uploadQueue = new Mock<IObjectUploadQueue>();
             _payloadAssembler = new Mock<IPayloadAssembler>();
             _tcpListener = new Mock<ITcpListener>();
+            _fileSystem = new Mock<IFileSystem>();
 
             _cancellationTokenSource = new CancellationTokenSource();
             _serviceScope = new Mock<IServiceScope>();
@@ -77,6 +79,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.HealthLevel7
             services.AddScoped(p => _mllpClientFactory.Object);
             services.AddScoped(p => _uploadQueue.Object);
             services.AddScoped(p => _payloadAssembler.Object);
+            services.AddScoped(p => _fileSystem.Object);
             _serviceProvider = services.BuildServiceProvider();
             _serviceScopeFactory.Setup(p => p.CreateScope()).Returns(_serviceScope.Object);
             _serviceScope.Setup(p => p.ServiceProvider).Returns(_serviceProvider);

--- a/src/InformaticsGateway/Test/Services/Http/MonaiHealthCheckTest.cs
+++ b/src/InformaticsGateway/Test/Services/Http/MonaiHealthCheckTest.cs
@@ -1,0 +1,90 @@
+﻿/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Monai.Deploy.InformaticsGateway.Repositories;
+using Monai.Deploy.InformaticsGateway.Services.Http;
+using Moq;
+using Xunit;
+
+namespace Monai.Deploy.InformaticsGateway.Test.Services.Http
+{
+    public class MonaiHealthCheckTest
+    {
+        private readonly Mock<IMonaiServiceLocator> _monaiServiceLocator;
+
+        public MonaiHealthCheckTest()
+        {
+            _monaiServiceLocator = new Mock<IMonaiServiceLocator>();
+        }
+
+        [Fact]
+        public async Task GivenAllServicesRunning_WhenCheckHealthAsyncIsCalled_ReturnsHealthy()
+        {
+            _monaiServiceLocator.Setup(p => p.GetServiceStatus()).Returns(new Dictionary<string, Api.Rest.ServiceStatus>()
+            {
+                { "A", Api.Rest.ServiceStatus.Running },
+                { "B", Api.Rest.ServiceStatus.Running },
+                { "C", Api.Rest.ServiceStatus.Running },
+            });
+
+            var svc = new MonaiHealthCheck(_monaiServiceLocator.Object);
+            var result = await svc.CheckHealthAsync(null);
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+        }
+
+        [Fact]
+        public async Task GivenSomeServicesNotRunning_WhenCheckHealthAsyncIsCalled_ReturnsDegraded()
+        {
+            _monaiServiceLocator.Setup(p => p.GetServiceStatus()).Returns(new Dictionary<string, Api.Rest.ServiceStatus>()
+            {
+                { "A", Api.Rest.ServiceStatus.Running },
+                { "B", Api.Rest.ServiceStatus.Cancelled },
+                { "C", Api.Rest.ServiceStatus.Stopped },
+            });
+
+            var svc = new MonaiHealthCheck(_monaiServiceLocator.Object);
+            var result = await svc.CheckHealthAsync(null);
+            Assert.Equal(HealthStatus.Degraded, result.Status);
+            Assert.Equal(Api.Rest.ServiceStatus.Cancelled, result.Data["B"]);
+            Assert.Equal(Api.Rest.ServiceStatus.Stopped, result.Data["C"]);
+        }
+
+        [Fact]
+        public async Task GivenAllServicesNotRunning_WhenCheckHealthAsyncIsCalled_ReturnsUnhealthy()
+        {
+            _monaiServiceLocator.Setup(p => p.GetServiceStatus()).Returns(new Dictionary<string, Api.Rest.ServiceStatus>()
+            {
+                { "A", Api.Rest.ServiceStatus.Stopped },
+                { "B", Api.Rest.ServiceStatus.Cancelled },
+                { "C", Api.Rest.ServiceStatus.Stopped },
+            });
+
+            var svc = new MonaiHealthCheck(_monaiServiceLocator.Object);
+            var result = await svc.CheckHealthAsync(null);
+
+            Assert.Equal(HealthStatus.Unhealthy, result.Status);
+            Assert.Equal(Api.Rest.ServiceStatus.Stopped, result.Data["A"]);
+            Assert.Equal(Api.Rest.ServiceStatus.Cancelled, result.Data["B"]);
+            Assert.Equal(Api.Rest.ServiceStatus.Stopped, result.Data["C"]);
+        }
+    }
+}

--- a/src/InformaticsGateway/Test/Services/Scp/ApplicationEntityHandlerTest.cs
+++ b/src/InformaticsGateway/Test/Services/Scp/ApplicationEntityHandlerTest.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.IO.Abstractions;
 using System.Threading.Tasks;
 using FellowOakDicom;
@@ -67,6 +68,8 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Scp
             _serviceScopeFactory.Setup(p => p.CreateScope()).Returns(_serviceScope.Object);
             _serviceScope.Setup(p => p.ServiceProvider).Returns(_serviceProvider);
 
+            _fileSystem.Setup(p => p.Path.Combine(It.IsAny<string>(), It.IsAny<string>())).Returns((string path1, string path2) => System.IO.Path.Combine(path1, path2));
+            _fileSystem.Setup(p => p.File.Create(It.IsAny<string>())).Returns(FileStream.Null);
             _logger.Setup(p => p.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
         }
 

--- a/src/InformaticsGateway/Test/Services/Scp/ApplicationEntityHandlerTest.cs
+++ b/src/InformaticsGateway/Test/Services/Scp/ApplicationEntityHandlerTest.cs
@@ -16,14 +16,17 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO.Abstractions;
 using System.Threading.Tasks;
 using FellowOakDicom;
 using FellowOakDicom.Network;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Monai.Deploy.InformaticsGateway.Api;
 using Monai.Deploy.InformaticsGateway.Api.Storage;
 using Monai.Deploy.InformaticsGateway.Common;
+using Monai.Deploy.InformaticsGateway.Configuration;
 using Monai.Deploy.InformaticsGateway.Services.Connectors;
 using Monai.Deploy.InformaticsGateway.Services.Scp;
 using Monai.Deploy.InformaticsGateway.Services.Storage;
@@ -41,7 +44,8 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Scp
         private readonly Mock<IServiceScope> _serviceScope;
         private readonly Mock<IPayloadAssembler> _payloadAssembler;
         private readonly Mock<IObjectUploadQueue> _uploadQueue;
-
+        private readonly IOptions<InformaticsGatewayConfiguration> _options;
+        private readonly Mock<IFileSystem> _fileSystem;
         private readonly IServiceProvider _serviceProvider;
 
         public ApplicationEntityHandlerTest()
@@ -52,10 +56,13 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Scp
 
             _payloadAssembler = new Mock<IPayloadAssembler>();
             _uploadQueue = new Mock<IObjectUploadQueue>();
+            _options = Options.Create<InformaticsGatewayConfiguration>(new InformaticsGatewayConfiguration());
+            _fileSystem = new Mock<IFileSystem>();
 
             var services = new ServiceCollection();
             services.AddScoped(p => _payloadAssembler.Object);
             services.AddScoped(p => _uploadQueue.Object);
+            services.AddScoped(p => _fileSystem.Object);
             _serviceProvider = services.BuildServiceProvider();
             _serviceScopeFactory.Setup(p => p.CreateScope()).Returns(_serviceScope.Object);
             _serviceScope.Setup(p => p.ServiceProvider).Returns(_serviceProvider);
@@ -66,10 +73,11 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Scp
         [RetryFact(5, 250)]
         public void GivenAApplicationEntityHandler_WhenInitialized_ExpectParametersToBeValidated()
         {
-            Assert.Throws<ArgumentNullException>(() => new ApplicationEntityHandler(null, null));
-            Assert.Throws<ArgumentNullException>(() => new ApplicationEntityHandler(_serviceScopeFactory.Object, null));
+            Assert.Throws<ArgumentNullException>(() => new ApplicationEntityHandler(null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new ApplicationEntityHandler(_serviceScopeFactory.Object, null, null));
+            Assert.Throws<ArgumentNullException>(() => new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object, null));
 
-            _ = new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object);
+            _ = new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object, _options);
         }
 
         [RetryFact(5, 250)]
@@ -83,7 +91,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Scp
                 IgnoredSopClasses = new List<string> { DicomUID.SecondaryCaptureImageStorage.UID }
             };
 
-            var handler = new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object);
+            var handler = new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object, _options);
 
             var request = GenerateRequest();
             var dicomToolkit = new DicomToolkit();
@@ -103,7 +111,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Scp
                 IgnoredSopClasses = new List<string> { DicomUID.SecondaryCaptureImageStorage.UID }
             };
 
-            var handler = new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object);
+            var handler = new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object, _options);
             handler.Configure(aet, Configuration.DicomJsonOptions.Complete, true);
 
             var request = GenerateRequest();
@@ -127,7 +135,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Scp
                 AllowedSopClasses = new List<string> { DicomUID.UltrasoundImageStorage.UID }
             };
 
-            var handler = new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object);
+            var handler = new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object, _options);
             handler.Configure(aet, Configuration.DicomJsonOptions.Complete, true);
 
             var request = GenerateRequest();
@@ -150,7 +158,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Scp
                 Workflows = new List<string>() { "AppA", "AppB", Guid.NewGuid().ToString() }
             };
 
-            var handler = new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object);
+            var handler = new ApplicationEntityHandler(_serviceScopeFactory.Object, _logger.Object, _options);
             handler.Configure(aet, Configuration.DicomJsonOptions.Complete, true);
 
             var request = GenerateRequest();

--- a/src/InformaticsGateway/Test/Services/Storage/ObjectUploadServiceTest.cs
+++ b/src/InformaticsGateway/Test/Services/Storage/ObjectUploadServiceTest.cs
@@ -45,7 +45,6 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Storage
         private readonly IObjectUploadQueue _uploadQueue;
         private readonly Mock<IStorageService> _storageService;
         private readonly Mock<IStorageMetadataWrapperRepository> _storageMetadataWrapperRepository;
-
         private readonly CancellationTokenSource _cancellationTokenSource;
         private readonly ServiceProvider _serviceProvider;
         private readonly Mock<IServiceScope> _serviceScope;
@@ -124,7 +123,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Storage
         }
 
         [Fact]
-        public void GivenAFhirFileStorageMetadata_WhenQueuedForUpload_ExpectSingleFileToBeUploaded()
+        public async Task GivenAFhirFileStorageMetadata_WhenQueuedForUpload_ExpectSingleFileToBeUploaded()
         {
             var countdownEvent = new CountdownEvent(1);
             _storageService.Setup(p => p.PutObjectAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<long>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
@@ -137,7 +136,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Storage
 
             Assert.Equal(ServiceStatus.Running, svc.Status);
 
-            var file = GenerateFhirFileStorageMetadata();
+            var file = await GenerateFhirFileStorageMetadata();
             _uploadQueue.Queue(file);
 
             Assert.True(countdownEvent.Wait(TimeSpan.FromSeconds(3)));
@@ -145,11 +144,11 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Storage
             _storageService.Verify(p => p.PutObjectAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<long>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()), Times.Once());
         }
 
-        private FhirFileStorageMetadata GenerateFhirFileStorageMetadata()
+        private async Task<FhirFileStorageMetadata> GenerateFhirFileStorageMetadata()
         {
             var file = new FhirFileStorageMetadata(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), FhirStorageFormat.Json);
 
-            file.SetDataStream("[]");
+            await file.SetDataStream("[]", TemporaryDataStorageLocation.Memory);
             return file;
         }
 
@@ -169,7 +168,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Storage
                 { DicomTag.SOPClassUID, DicomUID.SecondaryCaptureImageStorage.UID }
             };
             var dicomFile = new DicomFile(dataset);
-            await file.SetDataStreams(dicomFile, "[]");
+            await file.SetDataStreams(dicomFile, "[]", TemporaryDataStorageLocation.Memory);
             return file;
         }
     }

--- a/tests/Integration.Test/Monai.Deploy.InformaticsGateway.Integration.Test.csproj
+++ b/tests/Integration.Test/Monai.Deploy.InformaticsGateway.Integration.Test.csproj
@@ -33,8 +33,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Minio" Version="4.0.5" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.4" />
-    <PackageReference Include="Monai.Deploy.Storage.MinIO" Version="0.2.5" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.5" />
+    <PackageReference Include="Monai.Deploy.Storage.MinIO" Version="0.2.7" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />

--- a/tests/Integration.Test/configs/informatics-gateway.json
+++ b/tests/Integration.Test/configs/informatics-gateway.json
@@ -38,7 +38,7 @@
       }
     },
     "storage": {
-      "bufferRootPath": "./temp",
+      "bufferRootPath": "/payloads",
       "tempStorageRootPath": "/incoming",
       "bucketName": "monaideploy",
       "storageRootPath": "/payloads",

--- a/tests/Integration.Test/debug.sh
+++ b/tests/Integration.Test/debug.sh
@@ -55,9 +55,9 @@ function env_setup() {
 
     [ -d $BIN_DIR ] && info "Removing $BIN_DIR..." && sudo rm -r $BIN_DIR
 
-    if [[ $(docker-compose ps -q | wc -l) -ne 0 ]]; then
+    if [[ $(docker compose ps -q | wc -l) -ne 0 ]]; then
         info "Stopping existing services..."
-        docker-compose $LOADDEV down
+        docker compose $LOADDEV down
     fi
 
     if (dotnet tool list --global | grep livingdoc &>/dev/null); then
@@ -78,8 +78,8 @@ function build() {
 }
 
 function start_services() {
-    info "Starting dependencies docker-compose $LOADDEV up -d --force-recreate..."
-    docker-compose $LOADDEV up -d --force-recreate
+    info "Starting dependencies docker compose $LOADDEV up -d --force-recreate..."
+    docker compose $LOADDEV up -d --force-recreate
 
     HOST_IP=$(docker network inspect testrunner | jq -r .[0].IPAM.Config[0].Gateway)
     info "Host IP = $HOST_IP"
@@ -107,14 +107,14 @@ function tear_down() {
     set -e
 
     info "Stopping services..."
-    docker-compose $LOADDEV down --remove-orphans
+    docker compose $LOADDEV down --remove-orphans
 }
 
 function main() {
     env_setup "$@"
     build
     start_services
-    docker-compose logs -f
+    docker compose logs -f
 }
 
 main "$@"

--- a/tests/Integration.Test/run.sh
+++ b/tests/Integration.Test/run.sh
@@ -87,9 +87,9 @@ function env_setup() {
     esac
     done
 
-    if [[ $(docker-compose ps -q | wc -l) -ne 0 ]]; then
+    if [[ $(docker compose ps -q | wc -l) -ne 0 ]]; then
         info "Stopping existing services..."
-        docker-compose $LOADDEV down
+        docker compose $LOADDEV down
     fi
 
     if (dotnet tool list --global | grep livingdoc &>/dev/null); then
@@ -110,8 +110,8 @@ function build() {
 }
 
 function start_services() {
-    info "Starting dependencies docker-compose $LOADDEV up -d --force-recreate..."
-    docker-compose $LOADDEV up -d --force-recreate
+    info "Starting dependencies docker compose $LOADDEV up -d --force-recreate..."
+    docker compose $LOADDEV up -d --force-recreate
 
     HOST_IP=$(docker network inspect testrunner | jq -r .[0].IPAM.Config[0].Gateway)
     info "Host IP = $HOST_IP"
@@ -190,7 +190,7 @@ function generate_reports() {
 function save_logs() {
     [ -d $RUN_DIR ] && info "Clearning $RUN_DIR..." && sudo rm -r $RUN_DIR
     info "Saving service log..."
-    docker-compose $LOADDEV logs --no-color -t > "$LOG_DIR/services.log"
+    docker compose $LOADDEV logs --no-color -t > "$LOG_DIR/services.log"
 }
 
 function tear_down() {
@@ -200,7 +200,7 @@ function tear_down() {
     set -e
 
     info "Stopping services..."
-    docker-compose $LOADDEV down --remove-orphans
+    docker compose $LOADDEV down --remove-orphans
 }
 
 function main() {


### PR DESCRIPTION
### Description

Fixes #154, #149

- Added new configurations (`tempStorageLocation`) to enable users to use either `Memory` or `Disk` (default) for storing incoming data.  
- For `disk` option:
  - users must configure `bufferRootPath`.
  - `bufferSize` allows users to set disk buffer size with a default value of 128KB
- For `Memory` option:
  - `GC.Collect` is called upon a successful upload to force the garbage collector to compact the LOH


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] I have updated the changelog
