### PR TITLE
Reset stream position before upload

### DIFF
--- a/src/InformaticsGateway/Services/Storage/ObjectUploadService.cs
+++ b/src/InformaticsGateway/Services/Storage/ObjectUploadService.cs
@@ -214,6 +214,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Storage
                    })
                .ExecuteAsync(async () =>
                {
+                   storageObjectMetadata.Data.Seek(0, System.IO.SeekOrigin.Begin);
                    await _storageService.PutObjectAsync(
                        _configuration.Value.Storage.TemporaryStorageBucket,
                        storageObjectMetadata.GetTempStoragPath(_configuration.Value.Storage.TemporaryStorageRootPath),


### PR DESCRIPTION
### Description

Fixes #183 .

The data stream position needs to reset to the beginning before attempting to upload.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] I have updated the changelog
