### PR TITLE
Enable running integration test within VS

### DIFF
--- a/docker-compose/configs/orthanc.json
+++ b/docker-compose/configs/orthanc.json
@@ -1,0 +1,515 @@
+{
+  /**
+   * General configuration of Orthanc
+   **/
+
+  // The logical name of this instance of Orthanc. This one is
+  // displayed in Orthanc Explorer and at the URI "/system".
+  "Name": "Orthanc",
+
+  // Path to the directory that holds the heavyweight files (i.e. the
+  // raw DICOM instances). Backslashes must be either escaped by
+  // doubling them, or replaced by forward slashes "/".
+  "StorageDirectory": "/var/lib/orthanc/db",
+
+  // Path to the directory that holds the SQLite index (if unset, the
+  // value of StorageDirectory is used). This index could be stored on
+  // a RAM-drive or a SSD device for performance reasons.
+  "IndexDirectory": "/var/lib/orthanc/db",
+
+  // Path to the directory where Orthanc stores its large temporary
+  // files. The content of this folder can be safely deleted if
+  // Orthanc once stopped. The folder must exist. The corresponding
+  // filesystem must be properly sized, given that for instance a ZIP
+  // archive of DICOM images created by a job can weight several GBs,
+  // and that there might be up to "min(JobsHistorySize,
+  // MediaArchiveSize)" archives to be stored simultaneously. If not
+  // set, Orthanc will use the default temporary folder of the
+  // operating system (such as "/tmp/" on UNIX-like systems, or
+  // "C:/Temp" on Microsoft Windows).
+  // "TemporaryDirectory" : "/tmp/Orthanc/",
+
+  // Enable the transparent compression of the DICOM instances
+  "StorageCompression": false,
+
+  // Maximum size of the storage in MB (a value of "0" indicates no
+  // limit on the storage size)
+  "MaximumStorageSize": 0,
+
+  // Maximum number of patients that can be stored at a given time
+  // in the storage (a value of "0" indicates no limit on the number
+  // of patients)
+  "MaximumPatientCount": 0,
+
+  // List of paths to the custom Lua scripts that are to be loaded
+  // into this instance of Orthanc
+  "LuaScripts": [
+  ],
+
+  // List of paths to the plugins that are to be loaded into this
+  // instance of Orthanc (e.g. "./libPluginTest.so" for Linux, or
+  // "./PluginTest.dll" for Windows). These paths can refer to
+  // folders, in which case they will be scanned non-recursively to
+  // find shared libraries. Backslashes must be either escaped by
+  // doubling them, or replaced by forward slashes "/".
+  "Plugins": [
+    "/usr/share/orthanc/plugins",
+    "/usr/local/share/orthanc/plugins"
+  ],
+
+  // Maximum number of processing jobs that are simultaneously running
+  // at any given time. A value of "0" indicates to use all the
+  // available CPU logical cores. To emulate Orthanc <= 1.3.2, set
+  // this value to "1".
+  "ConcurrentJobs": 2,
+
+  /**
+   * Configuration of the HTTP server
+   **/
+
+  // Enable the HTTP server. If this parameter is set to "false",
+  // Orthanc acts as a pure DICOM server. The REST API and Orthanc
+  // Explorer will not be available.
+  "HttpServerEnabled": true,
+
+  // HTTP port for the REST services and for the GUI
+  "HttpPort": 8089,
+
+  // When the following option is "true", if an error is encountered
+  // while calling the REST API, a JSON message describing the error
+  // is put in the HTTP answer. This feature can be disabled if the
+  // HTTP client does not properly handles such answers.
+  "HttpDescribeErrors": true,
+
+  // Enable HTTP compression to improve network bandwidth utilization,
+  // at the expense of more computations on the server. Orthanc
+  // supports the "gzip" and "deflate" HTTP encodings.
+  "HttpCompressionEnabled": true,
+
+  /**
+   * Configuration of the DICOM server
+   **/
+
+  // Enable the DICOM server. If this parameter is set to "false",
+  // Orthanc acts as a pure REST server. It will not be possible to
+  // receive files or to do query/retrieve through the DICOM protocol.
+  "DicomServerEnabled": true,
+
+  // The DICOM Application Entity Title
+  "DicomAet": "ORTHANC",
+
+  // Check whether the called AET corresponds to the AET of Orthanc
+  // during an incoming DICOM SCU request
+  "DicomCheckCalledAet": false,
+
+  // The DICOM port
+  "DicomPort": 1114,
+
+  // The default encoding that is assumed for DICOM files without
+  // "SpecificCharacterSet" DICOM tag, and that is used when answering
+  // C-Find requests (including worklists). The allowed values are
+  // "Ascii", "Utf8", "Latin1", "Latin2", "Latin3", "Latin4",
+  // "Latin5", "Cyrillic", "Windows1251", "Arabic", "Greek", "Hebrew",
+  // "Thai", "Japanese", "Chinese", "JapaneseKanji", "Korean", and
+  // "SimplifiedChinese".
+  "DefaultEncoding": "Latin1",
+
+  // The transfer syntaxes that are accepted by Orthanc C-Store SCP
+  "DeflatedTransferSyntaxAccepted": true,
+  "JpegTransferSyntaxAccepted": true,
+  "Jpeg2000TransferSyntaxAccepted": true,
+  "JpegLosslessTransferSyntaxAccepted": true,
+  "JpipTransferSyntaxAccepted": true,
+  "Mpeg2TransferSyntaxAccepted": true,
+  "RleTransferSyntaxAccepted": true,
+
+  // Whether Orthanc accepts to act as C-Store SCP for unknown storage
+  // SOP classes (aka. "promiscuous mode")
+  "UnknownSopClassAccepted": false,
+
+  // Set the timeout (in seconds) after which the DICOM associations
+  // are closed by the Orthanc SCP (server) if no further DIMSE
+  // command is received from the SCU (client).
+  "DicomScpTimeout": 30,
+
+  /**
+   * Security-related options for the HTTP server
+   **/
+
+  // Whether remote hosts can connect to the HTTP server
+  "RemoteAccessAllowed": true,
+
+  // Whether or not SSL is enabled
+  "SslEnabled": false,
+
+  // Path to the SSL certificate in the PEM format (meaningful only if
+  // SSL is enabled)
+  "SslCertificate": "certificate.pem",
+
+  // Whether or not the password protection is enabled
+  "AuthenticationEnabled": true,
+
+  // The list of the registered users. Because Orthanc uses HTTP
+  // Basic Authentication, the passwords are stored as plain text.
+  "RegisteredUsers": {
+    "monai": "monai!"
+  },
+
+  /**
+   * Network topology
+   **/
+
+  // The list of the known DICOM modalities
+  "DicomModalities": {
+    /**
+     * Uncommenting the following line would enable Orthanc to
+     * connect to an instance of the "storescp" open-source DICOM
+     * store (shipped in the DCMTK distribution) started by the
+     * command line "storescp 2000".
+     **/
+    // "sample" : [ "STORESCP", "127.0.0.1", 2000 ]
+
+    /**
+     * A fourth parameter is available to enable patches for
+     * specific PACS manufacturers. The allowed values are currently:
+     * - "Generic" (default value),
+     * - "GenericNoWildcardInDates" (to replace "*" by "" in date fields
+     *   in outgoing C-Find requests originating from Orthanc),
+     * - "GenericNoUniversalWildcard" (to replace "*" by "" in all fields
+     *   in outgoing C-Find SCU requests originating from Orthanc),
+     * - "StoreScp" (storescp tool from DCMTK),
+     * - "ClearCanvas",
+     * - "Dcm4Chee",
+     * - "Vitrea",
+     * - "GE" (Enterprise Archive, MRI consoles and Advantage Workstation
+     *   from GE Healthcare).
+     *
+     * This parameter is case-sensitive.
+     **/
+
+    "localhost-STORESCP-104": [
+      "STORESCP",
+      "127.0.0.1",
+      104
+    ]
+    /**
+     * By default, the Orthanc SCP accepts all DICOM commands (C-ECHO,
+     * C-STORE, C-FIND, C-MOVE) issued by the registered remote SCU
+     * modalities. Starting with Orthanc 1.5.0, it is possible to
+     * specify which DICOM commands are allowed, separately for each
+     * remote modality, using the syntax below. The "AllowEcho" (resp.
+     * "AllowStore") option only has an effect respectively if global
+     * option "DicomAlwaysAllowEcho" (resp. "DicomAlwaysAllowStore")
+     * is set to false.
+     **/
+    //"untrusted" : {
+    //  "AET" : "ORTHANC",
+    //  "Port" : 104,
+    //  "Host" : "127.0.0.1",
+    //  "AllowEcho" : false,
+    //  "AllowFind" : false,
+    //  "AllowMove" : false,
+    //  "AllowStore" : true
+    //}
+  },
+
+  // Whether to store the DICOM modalities in the Orthanc database
+  // instead of in this configuration file (new in Orthanc 1.5.0)
+  "DicomModalitiesInDatabase": false,
+
+  // Whether the Orthanc SCP allows incoming C-Echo requests, even
+  // from SCU modalities it does not know about (i.e. that are not
+  // listed in the "DicomModalities" option above). Orthanc 1.3.0
+  // is the only version to behave as if this argument was set to "false".
+  "DicomAlwaysAllowEcho": true,
+
+  // Whether the Orthanc SCP allows incoming C-Store requests, even
+  // from SCU modalities it does not know about (i.e. that are not
+  // listed in the "DicomModalities" option above)
+  "DicomAlwaysAllowStore": true,
+
+  // Whether Orthanc checks the IP/hostname address of the remote
+  // modality initiating a DICOM connection (as listed in the
+  // "DicomModalities" option above). If this option is set to
+  // "false", Orthanc only checks the AET of the remote modality.
+  "DicomCheckModalityHost": false,
+
+  // The timeout (in seconds) after which the DICOM associations are
+  // considered as closed by the Orthanc SCU (client) if the remote
+  // DICOM SCP (server) does not answer.
+  "DicomScuTimeout": 10,
+
+  // The list of the known Orthanc peers
+  "OrthancPeers": {
+    /**
+     * Each line gives the base URL of an Orthanc peer, possibly
+     * followed by the username/password pair (if the password
+     * protection is enabled on the peer).
+     **/
+    // "peer"  : [ "http://127.0.0.1:8043/", "alice", "alicePassword" ]
+    // "peer2" : [ "http://127.0.0.1:8044/" ]
+
+    /**
+     * This is another, more advanced format to define Orthanc
+     * peers. It notably allows to specify HTTP headers, a HTTPS
+     * client certificate in the PEM format (as in the "--cert" option
+     * of curl), or to enable PKCS#11 authentication for smart cards.
+     **/
+    // "peer" : {
+    //   "Url" : "http://127.0.0.1:8043/",
+    //   "Username" : "alice",
+    //   "Password" : "alicePassword",
+    //   "HttpHeaders" : { "Token" : "Hello world" },
+    //   "CertificateFile" : "client.crt",
+    //   "CertificateKeyFile" : "client.key",
+    //   "CertificateKeyPassword" : "certpass",
+    //   "Pkcs11" : false
+    // }
+  },
+
+  // Whether to store the Orthanc peers in the Orthanc database
+  // instead of in this configuration file (new in Orthanc 1.5.0)
+  "OrthancPeersInDatabase": false,
+
+  // Parameters of the HTTP proxy to be used by Orthanc. If set to the
+  // empty string, no HTTP proxy is used. For instance:
+  //   "HttpProxy" : "192.168.0.1:3128"
+  //   "HttpProxy" : "proxyUser:proxyPassword@192.168.0.1:3128"
+  "HttpProxy": "",
+
+  // If set to "true", debug messages from libcurl will be issued
+  // whenever Orthanc makes an outgoing HTTP request. This is notably
+  // useful to debug HTTPS-related problems.
+  "HttpVerbose": true,
+
+  // Set the timeout for HTTP requests issued by Orthanc (in seconds).
+  "HttpTimeout": 10,
+
+  // Enable the verification of the peers during HTTPS requests. This
+  // option must be set to "false" if using self-signed certificates.
+  // Pay attention that setting this option to "false" results in
+  // security risks!
+  // Reference: http://curl.haxx.se/docs/sslcerts.html
+  "HttpsVerifyPeers": true,
+
+  // Path to the CA (certification authority) certificates to validate
+  // peers in HTTPS requests. From curl documentation ("--cacert"
+  // option): "Tells curl to use the specified certificate file to
+  // verify the peers. The file may contain multiple CA
+  // certificates. The certificate(s) must be in PEM format." On
+  // Debian-based systems, this option can be set to
+  // "/etc/ssl/certs/ca-certificates.crt"
+  "HttpsCACertificates": "",
+
+  /**
+   * Advanced options
+   **/
+
+  // Dictionary of symbolic names for the user-defined metadata. Each
+  // entry must map an unique string to an unique number between 1024
+  // and 65535. Reserved values:
+  //  - The Orthanc whole-slide imaging plugin uses metadata 4200
+  "UserMetadata": {
+    // "Sample" : 1024
+  },
+
+  // Dictionary of symbolic names for the user-defined types of
+  // attached files. Each entry must map an unique string to an unique
+  // number between 1024 and 65535. Optionally, a second argument can
+  // provided to specify a MIME content type for the attachment.
+  "UserContentType": {
+    // "sample" : 1024
+    // "sample2" : [ 1025, "application/pdf" ]
+  },
+
+  // Number of seconds without receiving any instance before a
+  // patient, a study or a series is considered as stable.
+  "StableAge": 60,
+
+  // By default, Orthanc compares AET (Application Entity Titles) in a
+  // case-insensitive way. Setting this option to "true" will enable
+  // case-sensitive matching.
+  "StrictAetComparison": false,
+
+  // When the following option is "true", the MD5 of the DICOM files
+  // will be computed and stored in the Orthanc database. This
+  // information can be used to detect disk corruption, at the price
+  // of a small performance overhead.
+  "StoreMD5ForAttachments": true,
+
+  // The maximum number of results for a single C-FIND request at the
+  // Patient, Study or Series level. Setting this option to "0" means
+  // no limit.
+  "LimitFindResults": 0,
+
+  // The maximum number of results for a single C-FIND request at the
+  // Instance level. Setting this option to "0" means no limit.
+  "LimitFindInstances": 0,
+
+  // The maximum number of active jobs in the Orthanc scheduler. When
+  // this limit is reached, the addition of new jobs is blocked until
+  // some job finishes.
+  "LimitJobs": 10,
+
+  // If this option is set to "true" (default behavior until Orthanc
+  // 1.3.2), Orthanc will log the resources that are exported to other
+  // DICOM modalities or Orthanc peers, inside the URI
+  // "/exports". Setting this option to "false" is useful to prevent
+  // the index to grow indefinitely in auto-routing tasks (this is the
+  // default behavior since Orthanc 1.4.0).
+  "LogExportedResources": false,
+
+  // Enable or disable HTTP Keep-Alive (persistent HTTP
+  // connections). Setting this option to "true" prevents Orthanc
+  // issue #32 ("HttpServer does not support multiple HTTP requests in
+  // the same TCP stream"), but can possibly slow down HTTP clients
+  // that do not support persistent connections. The default behavior
+  // used to be "false" in Orthanc <= 1.5.1. Setting this option to
+  // "false" is also recommended if Orthanc is compiled against
+  // Mongoose.
+  "KeepAlive": true,
+
+  // Enable or disable Nagle's algorithm. Only taken into
+  // consideration if Orthanc is compiled to use CivetWeb. Experiments
+  // show that best performance can be obtained by setting both
+  // "KeepAlive" and "TcpNoDelay" to "true". Beware however of
+  // caveats: https://eklitzke.org/the-caveats-of-tcp-nodelay
+  "TcpNoDelay": true,
+
+  // Number of threads that are used by the embedded HTTP server.
+  "HttpThreadsCount": 50,
+
+  // If this option is set to "false", Orthanc will run in index-only
+  // mode. The DICOM files will not be stored on the drive. Note that
+  // this option might prevent the upgrade to newer versions of Orthanc.
+  "StoreDicom": true,
+
+  // DICOM associations initiated by Lua scripts are kept open as long
+  // as new DICOM commands are issued. This option sets the number of
+  // seconds of inactivity to wait before automatically closing a
+  // DICOM association used by Lua. If set to 0, the connection is
+  // closed immediately.
+  "DicomAssociationCloseDelay": 5,
+
+  // Maximum number of query/retrieve DICOM requests that are
+  // maintained by Orthanc. The least recently used requests get
+  // deleted as new requests are issued.
+  "QueryRetrieveSize": 10,
+
+  // When handling a C-Find SCP request, setting this flag to "true"
+  // will enable case-sensitive match for PN value representation
+  // (such as PatientName). By default, the search is
+  // case-insensitive, which does not follow the DICOM standard.
+  "CaseSensitivePN": false,
+
+  // Configure PKCS#11 to use hardware security modules (HSM) and
+  // smart cards when carrying on HTTPS client authentication.
+  /**
+     "Pkcs11" : {
+       "Module" : "/usr/local/lib/libbeidpkcs11.so",
+       "Module" : "C:/Windows/System32/beidpkcs11.dll",
+       "Pin" : "1234",
+       "Verbose" : true
+     }
+   **/
+
+  // If set to "false", Orthanc will not load its default dictionary
+  // of private tags. This might be necessary if you cannot import a
+  // DICOM file encoded using the Implicit VR Endian transfer syntax,
+  // and containing private tags: Such an import error might stem from
+  // a bad dictionary. You can still list your private tags of
+  // interest in the "Dictionary" configuration option below.
+  "LoadPrivateDictionary": true,
+
+  // Locale to be used by Orthanc. Currently, only used if comparing
+  // strings in a case-insensitive way. It should be safe to keep this
+  // value undefined, which lets Orthanc autodetect the suitable locale.
+  // "Locale" : "en_US.UTF-8",
+
+  // Register a new tag in the dictionary of DICOM tags that are known
+  // to Orthanc. Each line must contain the tag (formatted as 2
+  // hexadecimal numbers), the value representation (2 upcase
+  // characters), a nickname for the tag, possibly the minimum
+  // multiplicity (> 0 with defaults to 1), possibly the maximum
+  // multiplicity (0 means arbitrary multiplicity, defaults to 1), and
+  // possibly the Private Creator (for private tags).
+  "Dictionary": {
+    // "0014,1020" : [ "DA", "ValidationExpiryDate", 1, 1 ]
+    // "00e1,10c2" : [ "UI", "PET-CT Multi Modality Name", 1, 1, "ELSCINT1" ]
+    // "7053,1003" : [ "ST", "Original Image Filename", 1, 1, "Philips PET Private Group" ]
+    // "2001,5f" : [ "SQ", "StackSequence", 1, 1, "Philips Imaging DD 001" ]
+  },
+
+  // Whether to run DICOM C-Move operations synchronously. If set to
+  // "false" (asynchronous mode), each incoming C-Move request results
+  // in the creation of a new background job. Up to Orthanc 1.3.2, the
+  // implicit behavior was to use synchronous C-Move ("true"). Between
+  // Orthanc 1.4.0 and 1.4.2, the default behavior was set to
+  // asynchronous C-Move ("false"). Since Orthanc 1.5.0, the default
+  // behavior is back to synchronous C-Move ("true", which ensures
+  // backward compatibility with Orthanc <= 1.3.2).
+  "SynchronousCMove": true,
+
+  // Maximum number of completed jobs that are kept in memory. A
+  // processing job is considered as complete once it is tagged as
+  // "Success" or "Failure". Since Orthanc 1.5.0, a value of "0"
+  // indicates to keep no job in memory (i.e. jobs are removed from
+  // the history as soon as they are completed), which prevents the
+  // use of some features of Orthanc (typically, synchronous mode in
+  // REST API) and should be avoided for non-developers.
+  "JobsHistorySize": 10,
+
+  // Whether to save the jobs into the Orthanc database. If this
+  // option is set to "true", the pending/running/completed jobs are
+  // automatically reloaded from the database if Orthanc is stopped
+  // then restarted (except if the "--no-jobs" command-line argument
+  // is specified). This option should be set to "false" if multiple
+  // Orthanc servers are using the same database (e.g. if PostgreSQL
+  // or MariaDB/MySQL is used).
+  "SaveJobs": true,
+
+  // Specifies how Orthanc reacts when it receives a DICOM instance
+  // whose SOPInstanceUID is already stored. If set to "true", the new
+  // instance replaces the old one. If set to "false", the new
+  // instance is discarded and the old one is kept. Up to Orthanc
+  // 1.4.1, the implicit behavior corresponded to "false".
+  "OverwriteInstances": false,
+
+  // Maximum number of ZIP/media archives that are maintained by
+  // Orthanc, as a response to the asynchronous creation of archives.
+  // The least recently used archives get deleted as new archives are
+  // generated. This option was introduced in Orthanc 1.5.0, and has
+  // no effect on the synchronous generation of archives.
+  "MediaArchiveSize": 1,
+
+  // Performance setting to specify how Orthanc accesses the storage
+  // area during C-FIND. Three modes are available: (1) "Always"
+  // allows Orthanc to read the storage area as soon as it needs an
+  // information that is not present in its database (slowest mode),
+  // (2) "Never" prevents Orthanc from accessing the storage area, and
+  // makes it uses exclusively its database (fastest mode), and (3)
+  // "Answers" allows Orthanc to read the storage area to generate its
+  // answers, but not to filter the DICOM resources (balance between
+  // the two modes). By default, the mode is "Always", which
+  // corresponds to the behavior of Orthanc <= 1.5.0.
+  "StorageAccessOnFind": "Always",
+
+  // Whether Orthanc monitors its metrics (new in Orthanc 1.5.4). If
+  // set to "true", the metrics can be retrieved at
+  // "/tools/metrics-prometheus" formetted using the Prometheus
+  // text-based exposition format.
+  "MetricsEnabled": true,
+
+  "RemoteAccessEnabled": true,
+  "DicomWeb": {
+    "Enable": true, // Whether DICOMweb support is enabled
+    "Root": "/dicom-web/", // Root URI of the DICOMweb API (for QIDO-RS, STOW-RS and WADO-RS)
+    "EnableWado": true, // Whether WADO-URI (previously known as WADO) support is enabled
+    "WadoRoot": "/wado", // Root URI of the WADO-URI (aka. WADO) API
+    "Host": "localhost:8089", // Hard-codes the name of the host for subsequent WADO-RS requests
+    "Ssl": false, // Whether HTTPS should be used for subsequent WADO-RS requests
+    "StowMaxInstances": 10, // For STOW-RS client, the maximum number of instances in one single HTTP query (0 = no limit)
+    "StowMaxSize": 10, // For STOW-RS client, the maximum size of the body in one single HTTP query (in MB, 0 = no limit)
+    "QidoCaseSensitive": true // For QIDO-RS server, whether search is case sensitive (since release 0.5)
+  }
+}

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -54,26 +54,46 @@ services:
     networks:
       - monaideploy
 
-  createbuckets:
-    image: minio/mc
+  #createbuckets:
+  #  image: minio/mc
+  #  environment:
+  #    MINIO_ROOT_USER: minioadmin
+  #    MINIO_ROOT_PASSWORD: minioadmin
+  #    BUCKET_NAME: monaideploy
+  #    ENDPOINT: http://minio:9000
+  #  depends_on:
+  #    minio:
+  #      condition: service_healthy
+  #  networks:
+  #    - monaideploy
+  #  entrypoint: >
+  #    /bin/sh -c "
+  #    until (/usr/bin/mc config host add myminio $$ENDPOINT $$MINIO_ROOT_USER $$MINIO_ROOT_PASSWORD) do echo '...waiting...' && sleep 1; done;
+  #    /usr/bin/mc mb myminio/$$BUCKET_NAME;
+  #    /usr/bin/mc policy set public myminio/$$BUCKET_NAME;
+  #    /usr/bin/mc ls myminio;
+  #    # exit 0
+  #    "
+
+  orthanc:
+    image: "jodogne/orthanc-plugins"
+    hostname: orthanc
+    volumes:
+      - ./configs/orthanc.json:/etc/orthanc/orthanc.json
+      - .run/orthanc:/var/lib/orthanc/db/
+    ports:
+      - "1114:1114"
+      - "8089:8089"
     environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin
-      BUCKET_NAME: monaideploy
-      ENDPOINT: http://minio:9000
-    depends_on:
-      minio:
-        condition: service_healthy
+      VERBOSE_ENABLED: "true"
     networks:
       - monaideploy
-    entrypoint: >
-      /bin/sh -c "
-      until (/usr/bin/mc config host add myminio $$ENDPOINT $$MINIO_ROOT_USER $$MINIO_ROOT_PASSWORD) do echo '...waiting...' && sleep 1; done;
-      /usr/bin/mc mb myminio/$$BUCKET_NAME;
-      /usr/bin/mc policy set public myminio/$$BUCKET_NAME;
-      /usr/bin/mc ls myminio;
-      # exit 0
-      "
+    healthcheck:
+      test: ["CMD", "/probes/test-aliveness.py"]
+      start_period: 10s
+      retries: 3
+      interval: 15s
+      timeout: 30s
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION}

--- a/tests/Integration.Test/Drivers/Configurations.cs
+++ b/tests/Integration.Test/Drivers/Configurations.cs
@@ -25,33 +25,28 @@ namespace Monai.Deploy.InformaticsGateway.Integration.Test.Drivers
     public sealed class Configurations
     {
         private readonly IConfiguration _config;
-        private readonly ISpecFlowOutputHelper _outputHelper;
 
-        public TestRunnerSettings TestRunnerOptions { get; private set; }
+        public static Configurations Instance { get; private set; }
+
         public InformaticsGatewaySettings InformaticsGatewayOptions { get; private set; }
-        public MessageBrokerSettings MessageBrokerOptions { get; private set; }
         public Dictionary<string, StudySpec> StudySpecs { get; private set; }
-        public StorageServiceSettings StorageServiceOptions { get; private set; }
         public OrthancSettings OrthancOptions { get; private set; }
 
-        public Configurations(ISpecFlowOutputHelper outputHelper)
+        private Configurations(ISpecFlowOutputHelper outputHelper)
         {
-            TestRunnerOptions = new TestRunnerSettings();
-            InformaticsGatewayOptions = new InformaticsGatewaySettings();
-            MessageBrokerOptions = new MessageBrokerSettings();
-            StorageServiceOptions = new StorageServiceSettings();
             OrthancOptions = new OrthancSettings();
-            _outputHelper = outputHelper ?? throw new ArgumentNullException(nameof(outputHelper));
             StudySpecs = LoadStudySpecs() ?? throw new NullReferenceException("study.json not found or empty.");
 
-            outputHelper.WriteLine($"StudySpecs={JsonSerializer.Serialize(StudySpecs)}");
-
             _config = new ConfigurationBuilder()
-                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT")}.json", optional: true, reloadOnChange: true)
+                .AddJsonFile("appsettings.ext.json", optional: false, reloadOnChange: false)
                 .Build();
 
-            LoadConfiguration();
+            LoadConfiguration(outputHelper);
+        }
+
+        internal static void Initialize(ISpecFlowOutputHelper outputHelper)
+        {
+            Instance = new Configurations(outputHelper);
         }
 
         private Dictionary<string, StudySpec> LoadStudySpecs()
@@ -68,47 +63,25 @@ namespace Monai.Deploy.InformaticsGateway.Integration.Test.Drivers
             return JsonSerializer.Deserialize<Dictionary<string, StudySpec>>(studyJson);
         }
 
-        private void LoadConfiguration()
+        private void LoadConfiguration(ISpecFlowOutputHelper outputHelper)
         {
-            _config.GetSection(nameof(TestRunnerSettings)).Bind(TestRunnerOptions);
-            _config.GetSection(nameof(InformaticsGatewaySettings)).Bind(InformaticsGatewayOptions);
-            _config.GetSection(nameof(MessageBrokerSettings)).Bind(MessageBrokerOptions);
-            _config.GetSection(nameof(StorageServiceSettings)).Bind(StorageServiceOptions);
+            InformaticsGatewayOptions = new InformaticsGatewaySettings();
+
             _config.GetSection(nameof(OrthancSettings)).Bind(OrthancOptions);
 
             var hostIp = Environment.GetEnvironmentVariable("HOST_IP");
             if (hostIp is not null)
             {
-                if (TestRunnerOptions.HostIp == "$HOST_IP")
-                {
-                    TestRunnerOptions.HostIp = hostIp;
-                }
-                _outputHelper.WriteLine("Test Runner Host/IP = {0}", TestRunnerOptions.HostIp);
-                if (InformaticsGatewayOptions.Host == "$HOST_IP")
-                {
-                    InformaticsGatewayOptions.Host = hostIp;
-                }
-                _outputHelper.WriteLine("Informatics Gateway Host/IP = {0}", InformaticsGatewayOptions.Host);
-                if (MessageBrokerOptions.Endpoint == "$HOST_IP")
-                {
-                    MessageBrokerOptions.Endpoint = hostIp;
-                }
-                _outputHelper.WriteLine("Message Broker Host/IP = {0}", MessageBrokerOptions.Endpoint);
-                if (StorageServiceOptions.Host == "$HOST_IP")
-                {
-                    StorageServiceOptions.Host = hostIp;
-                }
-                _outputHelper.WriteLine("Storage Service Host/IP = {0}", StorageServiceOptions.Host);
                 if (OrthancOptions.Host == "$HOST_IP")
                 {
                     OrthancOptions.Host = hostIp;
                 }
-                _outputHelper.WriteLine("Orthanc Host/IP = {0}", OrthancOptions.Host);
+                outputHelper.WriteLine("Orthanc Host/IP = {0}", OrthancOptions.Host);
                 if (OrthancOptions.DicomWebRoot.Contains("$HOST_IP"))
                 {
                     OrthancOptions.DicomWebRoot = OrthancOptions.DicomWebRoot.Replace("$HOST_IP", hostIp);
                 }
-                _outputHelper.WriteLine("Orthanc DICOM web endpoint = {0}", OrthancOptions.DicomWebRoot);
+                outputHelper.WriteLine("Orthanc DICOM web endpoint = {0}", OrthancOptions.DicomWebRoot);
             }
         }
     }
@@ -131,11 +104,6 @@ namespace Monai.Deploy.InformaticsGateway.Integration.Test.Drivers
         public string DicomWebRoot { get; set; }
 
         /// <summary>
-        /// Gets or sets the root URI of the Orthanc DICOMweb service used by IG.
-        /// </summary>
-        public string DicomWebRootInternal { get; set; }
-
-        /// <summary>
         /// Gets or sets the username to access Orthanc.
         /// </summary>
         public string Username { get; set; }
@@ -152,57 +120,17 @@ namespace Monai.Deploy.InformaticsGateway.Integration.Test.Drivers
         }
     }
 
-    public class StorageServiceSettings
-    {
-        public string Host { get; set; }
-        public int Port { get; set; }
-        public string AccessToken { get; set; }
-        public string AccessKey { get; set; }
-
-        public string Endpoint => $"{Host}:{Port}";
-    }
-
-    public class TestRunnerSettings
-    {
-        /// <summary>
-        /// Gets or sets the Host/IP Address used when createing a DICOM source.
-        /// If not specified, the test runner would query and use first available IPv4 IP Address.
-        /// </summary>
-        /// <value></value>
-        public string HostIp { get; set; }
-
-        /// <summary>
-        /// Gets or sets the name of the bucket test files are uploaded to.
-        /// </summary>
-        public string Bucket { get; set; }
-    }
-
     public class InformaticsGatewaySettings
     {
         /// <summary>
         /// Gets or set host name or IP address of the Informatics Gateway.
         /// </summary>
-        public string Host { get; set; }
-
-        /// <summary>
-        /// Gets or sets the DIMSE port of the Informatics Gateway.
-        /// </summary>
-        public int DimsePort { get; set; }
+        public string Host { get; set; } = "127.0.0.1";
 
         /// <summary>
         /// Gets or sets the RESTful API port of the Informatics Gateway.
         /// </summary>
-        public int ApiPort { get; set; }
-
-        /// <summary>
-        /// Gets or sets the HL7 listening port on the Informatics Gateway.
-        /// </summary>
-        public int Hl7Port { get; set; }
-
-        /// <summary>
-        /// Gets or sets the name of the bucket used by the storage service.
-        /// </summary>
-        public string StorageServiceBucketName { get; set; }
+        public int ApiPort { get; set; } = 5000;
 
         /// <summary>
         /// Gets the API endpoint of the Informatics Gateway.
@@ -215,7 +143,6 @@ namespace Monai.Deploy.InformaticsGateway.Integration.Test.Drivers
             }
         }
     }
-
     /// <summary>
     /// Maps modality type specs from study.json
     /// </summary>
@@ -238,14 +165,5 @@ namespace Monai.Deploy.InformaticsGateway.Integration.Test.Drivers
         {
             get { return (long)(SizeMax * OneMiB); }
         }
-    }
-
-    public class MessageBrokerSettings
-    {
-        public string Endpoint { get; set; }
-        public string Username { get; set; }
-        public string Password { get; set; }
-        public string VirtualHost { get; set; }
-        public string Exchange { get; set; }
     }
 }

--- a/tests/Integration.Test/Drivers/IDatabaseDataProvider.cs
+++ b/tests/Integration.Test/Drivers/IDatabaseDataProvider.cs
@@ -1,5 +1,5 @@
-/*
- * Copyright 2021-2022 MONAI Consortium
+﻿/*
+ * Copyright 2022 MONAI Consortium
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("Monai.Deploy.InformaticsGateway.Test")]
-[assembly: InternalsVisibleTo("Monai.Deploy.InformaticsGateway.Integration.Test")]
-
-// ILogger<ApplicationEntityManager>
-[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+namespace Monai.Deploy.InformaticsGateway.Integration.Test.Hooks
+{
+    public interface IDatabaseDataProvider
+    {
+        Task<string> InjectAcrRequest();
+    }
+}

--- a/tests/Integration.Test/Drivers/RabbitMqConsumer.cs
+++ b/tests/Integration.Test/Drivers/RabbitMqConsumer.cs
@@ -1,0 +1,72 @@
+﻿/*
+ * Copyright 2021-2022 MONAI Consortium
+ * Copyright 2019-2021 NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Concurrent;
+using Monai.Deploy.Messaging.Messages;
+using Monai.Deploy.Messaging.RabbitMQ;
+using TechTalk.SpecFlow.Infrastructure;
+
+namespace Monai.Deploy.InformaticsGateway.Integration.Test.Drivers
+{
+    internal class RabbitMqConsumer
+    {
+        private readonly string _queueName;
+        private readonly ISpecFlowOutputHelper _outputHelper;
+        private readonly ConcurrentBag<Message> _messages;
+
+        public IReadOnlyList<Message> Messages { get { return _messages.ToList(); } }
+        public CountdownEvent MessageWaitHandle { get; private set; }
+
+        public RabbitMqConsumer(RabbitMQMessageSubscriberService subscriberService, string queueName, ISpecFlowOutputHelper outputHelper)
+        {
+            if (subscriberService is null)
+            {
+                throw new ArgumentNullException(nameof(subscriberService));
+            }
+
+            if (string.IsNullOrWhiteSpace(queueName))
+            {
+                throw new ArgumentException($"'{nameof(queueName)}' cannot be null or whitespace.", nameof(queueName));
+            }
+
+            _queueName = queueName;
+            _outputHelper = outputHelper ?? throw new ArgumentNullException(nameof(outputHelper));
+            _messages = new ConcurrentBag<Message>();
+
+
+            subscriberService.Subscribe(
+                queueName,
+                queueName,
+                (eventArgs) =>
+                {
+                    _outputHelper.WriteLine($"Message received from queue {queueName} for {queueName}.");
+                    _messages.Add(eventArgs.Message);
+                    subscriberService.Acknowledge(eventArgs.Message);
+                    _outputHelper.WriteLine($"{DateTime.UtcNow} - {queueName} message received with correlation ID={eventArgs.Message.CorrelationId}, delivery tag={eventArgs.Message.DeliveryTag}");
+                    MessageWaitHandle?.Signal();
+
+                });
+        }
+
+        public void SetupMessageHandle(int count)
+        {
+            _outputHelper.WriteLine($"Expecting {count} {_queueName} messages from RabbitMQ");
+            _messages.Clear();
+            MessageWaitHandle = new CountdownEvent(count);
+        }
+    }
+}

--- a/tests/Integration.Test/Features/DicomWebExport.feature
+++ b/tests/Integration.Test/Features/DicomWebExport.feature
@@ -21,9 +21,10 @@ Feature: DICOMweb Export Service
     - [REQ-DCW-03] MIG SHALL be able to export to DICOMweb services via STOW-RS
     - [REQ-DCW-07] MIG SHALL support exporting data to multiple DICOMweb destinations
 
-    @messaging_export_complete @messaging @sql_inject_acr_request
+    @messaging_export_complete @messaging 
     Scenario: Export to a DICOMweb service
-        Given 1 <modality> studies for export
+        Given an ACR request in the database
+        And 1 <modality> studies for export
         When a export request is sent for 'md.export.request.monaidicomweb'
         Then Informatics Gateway exports the studies to Orthanc
 

--- a/tests/Integration.Test/Hooks/RabbitMqHooks.cs
+++ b/tests/Integration.Test/Hooks/RabbitMqHooks.cs
@@ -1,149 +1,157 @@
-/*
- * Copyright 2022 MONAI Consortium
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+///*
+// * Copyright 2022 MONAI Consortium
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// * http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
 
-using System.Globalization;
-using Monai.Deploy.InformaticsGateway.Configuration;
-using Monai.Deploy.InformaticsGateway.Integration.Test.Drivers;
-using Monai.Deploy.Messaging.Messages;
-using RabbitMQ.Client;
-using RabbitMQ.Client.Events;
-using TechTalk.SpecFlow.Infrastructure;
+//using System.Globalization;
+//using BoDi;
+//using Monai.Deploy.InformaticsGateway.Configuration;
+//using Monai.Deploy.InformaticsGateway.Integration.Test.Drivers;
+//using Monai.Deploy.Messaging.Messages;
+//using RabbitMQ.Client;
+//using RabbitMQ.Client.Events;
+//using TechTalk.SpecFlow.Infrastructure;
 
-namespace Monai.Deploy.InformaticsGateway.Integration.Test.Hooks
-{
-    [Binding]
-    public sealed class RabbitMqHooks
-    {
-        internal static readonly string ScenarioContextKey = "MESSAAGES";
-        private readonly ISpecFlowOutputHelper _outputHelper;
-        private readonly Configurations _configuration;
-        private readonly ScenarioContext _scenarioContext;
-        private readonly ConnectionFactory _connectionFactory;
-        private readonly MessageBrokerConfigurationKeys _configurationKeys;
-        private readonly IConnection _connection;
-        private readonly IModel _channel;
-        private string _consumerTag;
-        public CountdownEvent MessageWaitHandle { get; private set; }
+//namespace Monai.Deploy.InformaticsGateway.Integration.Test.Hooks
+//{
+//    [Binding]
+//    public sealed class RabbitMqHooks
+//    {
+//        internal static readonly string ScenarioContextKey = "MESSAAGES";
+//        private readonly ISpecFlowOutputHelper _outputHelper;
+//        private readonly Configurations _configuration;
+//        private readonly ScenarioContext _scenarioContext;
+//        private readonly InformaticsGatewayConfiguration _informaticsGatewayConfiguration;
+//        private readonly ConnectionFactory _connectionFactory;
+//        private readonly MessageBrokerConfigurationKeys _configurationKeys;
+//        private readonly IConnection _connection;
+//        private readonly IModel _channel;
+//        private string _consumerTag;
+//        public CountdownEvent MessageWaitHandle { get; private set; }
 
-        public RabbitMqHooks(ISpecFlowOutputHelper outputHelper, Configurations configuration, ScenarioContext scenarioContext)
-        {
-            _outputHelper = outputHelper ?? throw new ArgumentNullException(nameof(outputHelper));
-            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-            _scenarioContext = scenarioContext ?? throw new ArgumentNullException(nameof(scenarioContext));
-            _connectionFactory = new ConnectionFactory()
-            {
-                HostName = _configuration.MessageBrokerOptions.Endpoint,
-                UserName = _configuration.MessageBrokerOptions.Username,
-                Password = _configuration.MessageBrokerOptions.Password,
-                VirtualHost = _configuration.MessageBrokerOptions.VirtualHost
-            };
+//        public RabbitMqHooks(ISpecFlowOutputHelper outputHelper, Configurations configuration, ScenarioContext scenarioContext, ObjectContainer objectContainer)
+//        {
+//            if (objectContainer is null)
+//            {
+//                throw new ArgumentNullException(nameof(objectContainer));
+//            }
 
-            _configurationKeys = new MessageBrokerConfigurationKeys();
-            outputHelper.WriteLine($"Message broker connecting to {_configuration.MessageBrokerOptions.Endpoint}/{_configuration.MessageBrokerOptions.VirtualHost}");
-            _connection = _connectionFactory.CreateConnection();
-            _channel = _connection.CreateModel();
-            _channel.ExchangeDeclare(_configuration.MessageBrokerOptions.Exchange, ExchangeType.Topic, durable: true);
-            _channel.BasicQos(prefetchSize: 0, prefetchCount: 1, global: false);
-        }
+//            _outputHelper = outputHelper ?? throw new ArgumentNullException(nameof(outputHelper));
+//            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+//            _scenarioContext = scenarioContext ?? throw new ArgumentNullException(nameof(scenarioContext));
+//            _informaticsGatewayConfiguration = objectContainer.Resolve<InformaticsGatewayConfiguration>("InformaticsGatewayConfiguration");
+//            _connectionFactory = new ConnectionFactory()
+//            {
+//                HostName = _informaticsGatewayConfiguration.Messaging.PublisherSettings["endpoint"],
+//                UserName = _informaticsGatewayConfiguration.Messaging.PublisherSettings["username"],
+//                Password = _informaticsGatewayConfiguration.Messaging.PublisherSettings["password"],
+//                VirtualHost = _informaticsGatewayConfiguration.Messaging.PublisherSettings["virtualHost"],
+//            };
 
-        [BeforeScenario("@messaging_export_complete")]
-        public void BeforeMessagingExportComplete()
-        {
-            BeforeMessagingSubscribeTo(_configurationKeys.ExportComplete);
-        }
+//            _configurationKeys = new MessageBrokerConfigurationKeys();
+//            outputHelper.WriteLine($"Message broker connecting to {_informaticsGatewayConfiguration.Messaging.PublisherSettings["endpoint"]}/{_informaticsGatewayConfiguration.Messaging.PublisherSettings["virtualHost"]}");
+//            _connection = _connectionFactory.CreateConnection();
+//            _channel = _connection.CreateModel();
+//            _channel.ExchangeDeclare(_informaticsGatewayConfiguration.Messaging.PublisherSettings["exchange"], ExchangeType.Topic, durable: true);
+//            _channel.BasicQos(prefetchSize: 0, prefetchCount: 1, global: false);
+//        }
 
-        [BeforeScenario("@messaging_workflow_request")]
-        public void BeforeMessagingWorkflowRequest()
-        {
-            BeforeMessagingSubscribeTo(_configurationKeys.WorkflowRequest);
-        }
+//        [BeforeScenario("@messaging_export_complete")]
+//        public void BeforeMessagingExportComplete()
+//        {
+//            BeforeMessagingSubscribeTo(_configurationKeys.ExportComplete);
+//        }
 
-        private void BeforeMessagingSubscribeTo(string queue)
-        {
-            if (_scenarioContext.ContainsKey(ScenarioContextKey) && _scenarioContext[ScenarioContextKey] is IList<Message> messages && messages.Count > 0)
-            {
-                _outputHelper.WriteLine($"Existing message queue wasn't empty and contains {messages.Count} messages but will be cleared.");
-            }
-            _scenarioContext.Add(ScenarioContextKey, new List<Message>());
+//        [BeforeScenario("@messaging_workflow_request")]
+//        public void BeforeMessagingWorkflowRequest()
+//        {
+//            BeforeMessagingSubscribeTo(_configurationKeys.WorkflowRequest);
+//        }
 
-            _channel.QueueDeclare(queue: queue, durable: true, exclusive: false, autoDelete: false);
-            _channel.QueueBind(queue, _configuration.MessageBrokerOptions.Exchange, queue);
+//        private void BeforeMessagingSubscribeTo(string queue)
+//        {
+//            if (_scenarioContext.ContainsKey(ScenarioContextKey) && _scenarioContext[ScenarioContextKey] is IList<Message> messages && messages.Count > 0)
+//            {
+//                _outputHelper.WriteLine($"Existing message queue wasn't empty and contains {messages.Count} messages but will be cleared.");
+//            }
+//            _scenarioContext.Add(ScenarioContextKey, new List<Message>());
 
-            var messagesPurged = _channel.QueuePurge(queue);
-            _outputHelper.WriteLine($"{messagesPurged} messages purged from the queue {queue}.");
+//            _channel.QueueDeclare(queue: queue, durable: true, exclusive: false, autoDelete: false);
+//            _channel.QueueBind(queue, _informaticsGatewayConfiguration.Messaging.PublisherSettings["exchange"], queue);
 
-            var consumer = new EventingBasicConsumer(_channel);
-            consumer.Received += (model, eventArgs) =>
-            {
-                _outputHelper.WriteLine($"Message received from queue {queue} for {queue}.");
+//            var messagesPurged = _channel.QueuePurge(queue);
+//            _outputHelper.WriteLine($"{messagesPurged} messages purged from the queue {queue}.");
 
-                var messsage = new Message(
-                     body: eventArgs.Body.ToArray(),
-                     messageDescription: eventArgs.BasicProperties.Type,
-                     messageId: eventArgs.BasicProperties.MessageId,
-                     applicationId: eventArgs.BasicProperties.AppId,
-                     contentType: eventArgs.BasicProperties.ContentType,
-                     correlationId: eventArgs.BasicProperties.CorrelationId,
-                     creationDateTime: DateTimeOffset.FromUnixTimeSeconds(eventArgs.BasicProperties.Timestamp.UnixTime),
-                     deliveryTag: eventArgs.DeliveryTag.ToString(CultureInfo.InvariantCulture));
+//            var consumer = new EventingBasicConsumer(_channel);
+//            consumer.Received += (model, eventArgs) =>
+//            {
+//                _outputHelper.WriteLine($"Message received from queue {queue} for {queue}.");
 
-                (_scenarioContext[ScenarioContextKey] as IList<Message>)?.Add(messsage);
-                _channel.BasicAck(eventArgs.DeliveryTag, false);
-                _outputHelper.WriteLine($"{DateTime.UtcNow} - {queue} message received with correlation ID={messsage.CorrelationId}, delivery tag={messsage.DeliveryTag}");
-                MessageWaitHandle.Signal();
-            };
-            _channel.BasicQos(0, 0, false);
-            _consumerTag = _channel.BasicConsume(queue, false, consumer);
-            _outputHelper.WriteLine($"Listening for messages from {_configuration.MessageBrokerOptions.Endpoint}/{_configuration.MessageBrokerOptions.VirtualHost}. Exchange={_configuration.MessageBrokerOptions.Exchange}, Queue={queue}, Routing Key={queue}");
-        }
+//                var messsage = new Message(
+//                     body: eventArgs.Body.ToArray(),
+//                     messageDescription: eventArgs.BasicProperties.Type,
+//                     messageId: eventArgs.BasicProperties.MessageId,
+//                     applicationId: eventArgs.BasicProperties.AppId,
+//                     contentType: eventArgs.BasicProperties.ContentType,
+//                     correlationId: eventArgs.BasicProperties.CorrelationId,
+//                     creationDateTime: DateTimeOffset.FromUnixTimeSeconds(eventArgs.BasicProperties.Timestamp.UnixTime),
+//                     deliveryTag: eventArgs.DeliveryTag.ToString(CultureInfo.InvariantCulture));
 
-        internal void Publish(string routingKey, Message message)
-        {
-            var propertiesDictionary = new Dictionary<string, object>
-            {
-                { "CreationDateTime", message.CreationDateTime.ToString("o") }
-            };
+//                (_scenarioContext[ScenarioContextKey] as IList<Message>)?.Add(messsage);
+//                _channel.BasicAck(eventArgs.DeliveryTag, false);
+//                _outputHelper.WriteLine($"{DateTime.UtcNow} - {queue} message received with correlation ID={messsage.CorrelationId}, delivery tag={messsage.DeliveryTag}");
+//                MessageWaitHandle.Signal();
+//            };
+//            _channel.BasicQos(0, 0, false);
+//            _consumerTag = _channel.BasicConsume(queue, false, consumer);
+//            _outputHelper.WriteLine($"Listening for messages from {_informaticsGatewayConfiguration.Messaging.PublisherSettings["endpoint"]}/{_informaticsGatewayConfiguration.Messaging.PublisherSettings["virtualHost"]}, Queue={queue}, Routing Key={queue}");
+//        }
 
-            var properties = _channel.CreateBasicProperties();
-            properties.Persistent = true;
-            properties.ContentType = message.ContentType;
-            properties.MessageId = message.MessageId;
-            properties.AppId = message.ApplicationId;
-            properties.CorrelationId = message.CorrelationId;
-            properties.DeliveryMode = 2;
-            properties.Type = message.MessageDescription;
-            properties.Timestamp = new AmqpTimestamp(message.CreationDateTime.ToUnixTimeSeconds());
+//        internal void Publish(string routingKey, Message message)
+//        {
+//            var propertiesDictionary = new Dictionary<string, object>
+//            {
+//                { "CreationDateTime", message.CreationDateTime.ToString("o") }
+//            };
 
-            properties.Headers = propertiesDictionary;
-            _channel.BasicPublish(exchange: _configuration.MessageBrokerOptions.Exchange,
-                                 routingKey: routingKey,
-                                 basicProperties: properties,
-                                 body: message.Body);
-        }
+//            var properties = _channel.CreateBasicProperties();
+//            properties.Persistent = true;
+//            properties.ContentType = message.ContentType;
+//            properties.MessageId = message.MessageId;
+//            properties.AppId = message.ApplicationId;
+//            properties.CorrelationId = message.CorrelationId;
+//            properties.DeliveryMode = 2;
+//            properties.Type = message.MessageDescription;
+//            properties.Timestamp = new AmqpTimestamp(message.CreationDateTime.ToUnixTimeSeconds());
 
-        [AfterScenario("@messaging")]
-        public void AfterScenario()
-        {
-            _scenarioContext.Remove(ScenarioContextKey);
-            _channel.BasicCancel(_consumerTag);
-        }
+//            properties.Headers = propertiesDictionary;
+//            _channel.BasicPublish(exchange: _informaticsGatewayConfiguration.Messaging.PublisherSettings["exchange"],
+//                                 routingKey: routingKey,
+//                                 basicProperties: properties,
+//                                 body: message.Body);
+//        }
 
-        public void SetupMessageHandle(int count)
-        {
-            MessageWaitHandle = new CountdownEvent(count);
-        }
-    }
-}
+//        [AfterScenario("@messaging")]
+//        public void AfterScenario()
+//        {
+//            _scenarioContext.Remove(ScenarioContextKey);
+//            _channel.BasicCancel(_consumerTag);
+//        }
+
+//        public void SetupMessageHandle(int count)
+//        {
+//            MessageWaitHandle = new CountdownEvent(count);
+//        }
+//    }
+//}

--- a/tests/Integration.Test/Hooks/TestHooks.cs
+++ b/tests/Integration.Test/Hooks/TestHooks.cs
@@ -1,0 +1,152 @@
+﻿/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Diagnostics;
+using BoDi;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Monai.Deploy.InformaticsGateway.Configuration;
+using Monai.Deploy.InformaticsGateway.Database;
+using Monai.Deploy.InformaticsGateway.Database.EntityFramework;
+using Monai.Deploy.InformaticsGateway.Integration.Test.Drivers;
+using Monai.Deploy.InformaticsGateway.Repositories;
+using Monai.Deploy.Messaging.RabbitMQ;
+using Monai.Deploy.WorkflowManager.IntegrationTests.Support;
+using TechTalk.SpecFlow.Infrastructure;
+
+namespace Monai.Deploy.InformaticsGateway.Integration.Test.Hooks
+{
+    [Binding]
+    public sealed class TestHooks
+    {
+        private static IHost s_informaticsGatewayHost;
+        private static IOptions<InformaticsGatewayConfiguration> s_options;
+        private static RabbitMQConnectionFactory s_rabbitMqConnectionFactory;
+        private static RabbitMQMessagePublisherService s_rabbitMqPublisher;
+        private static RabbitMqConsumer s_rabbitMqConsumer_WorkflowRequest;
+        private static RabbitMqConsumer s_rabbitMqConsumer_ExportComplete;
+        private static EfDataProvider s_database;
+        private readonly IObjectContainer _objectContainer;
+
+        public TestHooks(IObjectContainer objectContainer)
+        {
+            _objectContainer = objectContainer;
+        }
+
+        /// <summary>
+        /// Runs before all tests to create static implementions of Rabbit and Mongo clients as well as starting the WorkflowManager using WebApplicationFactory.
+        /// </summary>
+        [BeforeTestRun(Order = 0)]
+        public static void Init(ISpecFlowOutputHelper outputHelper)
+        {
+            SetupInformaticsGateway();
+            using var scope = s_informaticsGatewayHost.Services.CreateScope();
+            s_options = scope.ServiceProvider.GetRequiredService<IOptions<InformaticsGatewayConfiguration>>();
+            Configurations.Initialize(outputHelper);
+            RabbitConnectionFactory.DeleteAllQueues(s_options.Value);
+
+            s_rabbitMqConnectionFactory = new RabbitMQConnectionFactory(
+                scope.ServiceProvider.GetRequiredService<ILogger<RabbitMQConnectionFactory>>());
+
+            s_rabbitMqPublisher = new RabbitMQMessagePublisherService(
+                Options.Create(s_options.Value.Messaging),
+                scope.ServiceProvider.GetRequiredService<ILogger<RabbitMQMessagePublisherService>>(),
+                s_rabbitMqConnectionFactory);
+
+            var rabbitMqSubscriber_WorkflowRequest = new RabbitMQMessageSubscriberService(
+                Options.Create(s_options.Value.Messaging),
+                scope.ServiceProvider.GetRequiredService<ILogger<RabbitMQMessageSubscriberService>>(),
+                s_rabbitMqConnectionFactory);
+
+            s_rabbitMqConsumer_WorkflowRequest = new RabbitMqConsumer(rabbitMqSubscriber_WorkflowRequest, s_options.Value.Messaging.Topics.WorkflowRequest, outputHelper);
+
+            var rabbitMqSubscriber_ExportComplete = new RabbitMQMessageSubscriberService(
+                Options.Create(s_options.Value.Messaging),
+                scope.ServiceProvider.GetRequiredService<ILogger<RabbitMQMessageSubscriberService>>(),
+                s_rabbitMqConnectionFactory);
+
+            s_rabbitMqConsumer_ExportComplete = new RabbitMqConsumer(rabbitMqSubscriber_ExportComplete, s_options.Value.Messaging.Topics.ExportComplete, outputHelper);
+
+            s_database = GetDatabase(scope.ServiceProvider, outputHelper);
+
+            var serviceLocator = scope.ServiceProvider.GetRequiredService<IMonaiServiceLocator>();
+            s_informaticsGatewayHost.Start();
+
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+            do
+            {
+                var statuses = serviceLocator.GetServiceStatus();
+                if (statuses.Values.All(p => p == Api.Rest.ServiceStatus.Running))
+                {
+                    break;
+                }
+
+                if (stopwatch.Elapsed > TimeSpan.FromSeconds(30))
+                {
+                    throw new ApplicationException("Timeout waiting for all services to be ready.");
+                }
+            } while (true);
+        }
+
+        private static EfDataProvider GetDatabase(IServiceProvider serviceProvider, ISpecFlowOutputHelper outputHelper)
+        {
+            var config = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: false)
+                .Build();
+            var connectionString = config.GetSection("ConnectionStrings:InformaticsGatewayDatabase").Value;
+
+            var builder = new DbContextOptionsBuilder<InformaticsGatewayContext>();
+            builder.UseSqlite(connectionString);
+            var dbContext = new InformaticsGatewayContext(builder.Options);
+            return new EfDataProvider(outputHelper, Configurations.Instance, dbContext);
+        }
+
+        [BeforeScenario(Order = 0)]
+        public void SetUp(ScenarioContext scenarioContext, ISpecFlowOutputHelper outputHelper)
+        {
+            _objectContainer.RegisterInstanceAs(Configurations.Instance);
+            _objectContainer.RegisterInstanceAs<IDatabaseDataProvider>(s_database, "Database");
+            _objectContainer.RegisterInstanceAs(s_options.Value, "InformaticsGatewayConfiguration");
+            _objectContainer.RegisterInstanceAs(s_rabbitMqPublisher, "MessagingPublisher");
+            _objectContainer.RegisterInstanceAs(s_rabbitMqConsumer_WorkflowRequest, "WorkflowRequestSubscriber");
+            _objectContainer.RegisterInstanceAs(s_rabbitMqConsumer_ExportComplete, "ExportCompleteSubscriber");
+        }
+
+        [AfterTestRun(Order = 1)]
+        public static void Shtudown()
+        {
+            s_informaticsGatewayHost.StopAsync();
+        }
+
+        [AfterTestRun(Order = 0)]
+        [AfterScenario]
+        public static void ClearTestData()
+        {
+            RabbitConnectionFactory.PurgeAllQueues(s_options.Value.Messaging);
+        }
+
+        private static void SetupInformaticsGateway()
+        {
+            s_informaticsGatewayHost = Program.CreateHostBuilder(Array.Empty<string>()).Build();
+            s_informaticsGatewayHost.MigrateDatabase();
+        }
+    }
+}

--- a/tests/Integration.Test/Monai.Deploy.InformaticsGateway.Integration.Test.csproj
+++ b/tests/Integration.Test/Monai.Deploy.InformaticsGateway.Integration.Test.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
   ~ Copyright 2022 MONAI Consortium
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -51,7 +51,6 @@
 
   <ItemGroup>
     <Folder Include="Features\" />
-    <Folder Include="Support\" />
   </ItemGroup>
 
   <ItemGroup>
@@ -65,14 +64,24 @@
     <ProjectReference Include="..\..\src\Database\EntityFramework\Monai.Deploy.InformaticsGateway.Database.EntityFramework.csproj" />
     <ProjectReference Include="..\..\src\Database\Monai.Deploy.InformaticsGateway.Database.csproj" />
     <ProjectReference Include="..\..\src\DicomWebClient\Monai.Deploy.InformaticsGateway.DicomWeb.Client.csproj" />
+    <ProjectReference Include="..\..\src\InformaticsGateway\Monai.Deploy.InformaticsGateway.csproj" />
   </ItemGroup>
 
+  <Target Name="CopyPluginsBuild" AfterTargets="Build">
+    <ItemGroup>
+      <PluginDlls Include="$(OutDir)Monai.Deploy.Messaging.RabbitMQ.dll;$(OutDir)Monai.Deploy.Storage.MinIO.dll;$(OutDir)Minio.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(PluginDlls)" DestinationFolder="$(OutDir)\plug-ins\" SkipUnchangedFiles="true" />
+    <Message Text="Files copied successfully to $(OutDir)\plug-ins\." Importance="high" />
+  </Target>
+  
   <Target Name="CopyTestConfigurations" AfterTargets="AfterBuild">
     <PropertyGroup>
       <STUDYJSON Condition=" '$(STUDYJSON)' == '' ">study.json</STUDYJSON>
     </PropertyGroup>
     <Message Importance="High" Text="Copying $(STUDYJSON) to $(OutDir)" />
     <Copy OverwriteReadOnlyFiles="true" SourceFiles="appsettings.json" DestinationFolder="$(OutDir)" />
+    <Copy OverwriteReadOnlyFiles="true" SourceFiles="appsettings.ext.json" DestinationFolder="$(OutDir)" />
     <Copy OverwriteReadOnlyFiles="true" SourceFiles="$(STUDYJSON)" DestinationFiles="$(OutDir)\study.json" />
   </Target>
 </Project>

--- a/tests/Integration.Test/Monai.Deploy.InformaticsGateway.Integration.Test.csproj
+++ b/tests/Integration.Test/Monai.Deploy.InformaticsGateway.Integration.Test.csproj
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
   ~ Copyright 2022 MONAI Consortium
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -64,7 +64,6 @@
     <ProjectReference Include="..\..\src\Configuration\Monai.Deploy.InformaticsGateway.Configuration.csproj" />
     <ProjectReference Include="..\..\src\Database\EntityFramework\Monai.Deploy.InformaticsGateway.Database.EntityFramework.csproj" />
     <ProjectReference Include="..\..\src\Database\Monai.Deploy.InformaticsGateway.Database.csproj" />
-    <ProjectReference Include="..\..\src\Database\Sqlite\Monai.Deploy.InformaticsGateway.Database.EntityFramework.csproj" />
     <ProjectReference Include="..\..\src\DicomWebClient\Monai.Deploy.InformaticsGateway.DicomWeb.Client.csproj" />
   </ItemGroup>
 

--- a/tests/Integration.Test/StepDefinitions/DicomWebStowServiceStepDefinitions.cs
+++ b/tests/Integration.Test/StepDefinitions/DicomWebStowServiceStepDefinitions.cs
@@ -16,11 +16,13 @@
 
 using System.Net;
 using Ardalis.GuardClauses;
+using BoDi;
+using Monai.Deploy.InformaticsGateway.Configuration;
 using Monai.Deploy.InformaticsGateway.DicomWeb.Client;
 using Monai.Deploy.InformaticsGateway.DicomWeb.Client.API;
 using Monai.Deploy.InformaticsGateway.Integration.Test.Common;
 using Monai.Deploy.InformaticsGateway.Integration.Test.Drivers;
-using Monai.Deploy.InformaticsGateway.Integration.Test.Hooks;
+using Monai.Deploy.Messaging.RabbitMQ;
 using TechTalk.SpecFlow.Infrastructure;
 
 namespace Monai.Deploy.InformaticsGateway.Integration.Test.StepDefinitions
@@ -29,24 +31,27 @@ namespace Monai.Deploy.InformaticsGateway.Integration.Test.StepDefinitions
     [CollectionDefinition("SpecFlowNonParallelizableFeatures", DisableParallelization = true)]
     public class DicomWebStowServiceStepDefinitions
     {
+        private readonly InformaticsGatewayConfiguration _informaticsGatewayConfiguration;
         private readonly ScenarioContext _scenarioContext;
         private readonly ISpecFlowOutputHelper _outputHelper;
         private readonly Configurations _configuration;
         private readonly DicomInstanceGenerator _dicomInstanceGenerator;
-        private readonly RabbitMqHooks _rabbitMqHooks;
+        private readonly RabbitMqConsumer _receivedMessages;
 
         public DicomWebStowServiceStepDefinitions(
+            ObjectContainer objectContainer,
             ScenarioContext scenarioContext,
             ISpecFlowOutputHelper outputHelper,
             Configurations configuration,
-            DicomInstanceGenerator dicomInstanceGenerator,
-            RabbitMqHooks rabbitMqHooks)
+            DicomInstanceGenerator dicomInstanceGenerator)
         {
+            _informaticsGatewayConfiguration = objectContainer.Resolve<InformaticsGatewayConfiguration>("InformaticsGatewayConfiguration");
             _scenarioContext = scenarioContext ?? throw new ArgumentNullException(nameof(scenarioContext));
             _outputHelper = outputHelper ?? throw new ArgumentNullException(nameof(outputHelper));
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _dicomInstanceGenerator = dicomInstanceGenerator ?? throw new ArgumentNullException(nameof(dicomInstanceGenerator));
-            _rabbitMqHooks = rabbitMqHooks ?? throw new ArgumentNullException(nameof(rabbitMqHooks));
+
+            _receivedMessages = objectContainer.Resolve<RabbitMqConsumer>("WorkflowRequestSubscriber");
         }
 
         [Given(@"a workflow named '(.*)'")]

--- a/tests/Integration.Test/Support/RabbitConnectionFactory.cs
+++ b/tests/Integration.Test/Support/RabbitConnectionFactory.cs
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Monai.Deploy.InformaticsGateway.Configuration;
+using RabbitMQ.Client;
+
+namespace Monai.Deploy.WorkflowManager.IntegrationTests.Support
+{
+    public static class RabbitConnectionFactory
+    {
+        private static IModel? Channel { get; set; }
+
+        public static IModel GetRabbitConnection(MessageBrokerConfiguration configuration)
+        {
+            var connectionFactory = new ConnectionFactory
+            {
+                HostName = configuration.PublisherSettings["endpoint"],
+                UserName = configuration.PublisherSettings["username"],
+                Password = configuration.PublisherSettings["password"],
+                VirtualHost = configuration.PublisherSettings["virtualHost"],
+            };
+
+            Channel = connectionFactory.CreateConnection().CreateModel();
+
+            return Channel;
+        }
+
+        public static void DeleteQueue(MessageBrokerConfiguration configuration, string queueName)
+        {
+            if (Channel is null)
+            {
+                GetRabbitConnection(configuration);
+            }
+
+            Channel?.QueueDelete(queueName);
+        }
+
+        public static void PurgeQueue(MessageBrokerConfiguration configuration, string queueName)
+        {
+            if (Channel is null || Channel.IsClosed)
+            {
+                GetRabbitConnection(configuration);
+            }
+
+            try
+            {
+                Channel?.QueuePurge(queueName);
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        public static void DeleteAllQueues(InformaticsGatewayConfiguration configuration)
+        {
+            DeleteQueue(configuration.Messaging, configuration.Messaging.Topics.WorkflowRequest);
+            DeleteQueue(configuration.Messaging, configuration.Messaging.Topics.ExportComplete);
+            DeleteQueue(configuration.Messaging, $"{configuration.Messaging.Topics.ExportRequestPrefix}.{configuration.Dicom.Scu.AgentName}");
+            DeleteQueue(configuration.Messaging, $"{configuration.Messaging.Topics.ExportRequestPrefix}.{configuration.DicomWeb.AgentName}");
+            DeleteQueue(configuration.Messaging, $"{configuration.Messaging.Topics.WorkflowRequest}-dead-letter");
+            DeleteQueue(configuration.Messaging, $"{configuration.Messaging.Topics.ExportComplete}-dead-letter");
+            DeleteQueue(configuration.Messaging, $"{configuration.Messaging.Topics.ExportRequestPrefix}.{configuration.Dicom.Scu.AgentName}-dead-letter");
+            DeleteQueue(configuration.Messaging, $"{configuration.Messaging.Topics.ExportRequestPrefix}.{configuration.DicomWeb.AgentName}-dead-letter");
+        }
+
+        public static void PurgeAllQueues(MessageBrokerConfiguration configuration)
+        {
+            PurgeQueue(configuration, configuration.Topics.WorkflowRequest);
+            PurgeQueue(configuration, configuration.Topics.ExportComplete);
+            PurgeQueue(configuration, configuration.Topics.ExportRequestPrefix); // TODO
+            PurgeQueue(configuration, $"{configuration.Topics.WorkflowRequest}-dead-letter");
+            PurgeQueue(configuration, $"{configuration.Topics.ExportComplete}-dead-letter");
+            PurgeQueue(configuration, $"{configuration.Topics.ExportRequestPrefix}-dead-letter"); // TODO
+        }
+    }
+}

--- a/tests/Integration.Test/appsettings.ext.json
+++ b/tests/Integration.Test/appsettings.ext.json
@@ -1,0 +1,9 @@
+﻿{
+  "OrthancSettings": {
+    "Host": "127.0.0.1",
+    "dimsePort": 1114,
+    "dicomWebRoot": "http://127.0.0.1:8089/dicom-web/",
+    "username": "monai",
+    "password": "monai!"
+  }
+}

--- a/tests/Integration.Test/appsettings.json
+++ b/tests/Integration.Test/appsettings.json
@@ -1,34 +1,82 @@
-﻿{
-  "TestRunnerSettings": {
-    "HostIp": "$HOST_IP",
-    "Bucket": "monaideploy"
+{
+  "ConnectionStrings": {
+    "Type": "Sqlite",
+    "InformaticsGatewayDatabase": "Data Source=./mig.db"
   },
-  "InformaticsGatewaySettings": {
-    "host": "$HOST_IP",
-    "dimsePort": 104,
-    "apiPort": 5000,
-    "Hl7Port": 2575
+  "InformaticsGateway": {
+    "dicom": {
+      "scp": {
+        "port": 1104,
+        "logDimseDatasets": false,
+        "rejectUnknownSources": true
+      },
+      "scu": {
+        "aeTitle": "MONAISCU",
+        "logDimseDatasets": false,
+        "logDataPDUs": false
+      }
+    },
+    "messaging": {
+      "publisherServiceAssemblyName": "Monai.Deploy.Messaging.RabbitMQ.RabbitMQMessagePublisherService, Monai.Deploy.Messaging.RabbitMQ",
+      "publisherSettings": {
+        "endpoint": "localhost",
+        "username": "rabbitmq",
+        "password": "rabbitmq",
+        "virtualHost": "monaideploy",
+        "exchange": "monaideploy"
+      },
+      "subscriberServiceAssemblyName": "Monai.Deploy.Messaging.RabbitMQ.RabbitMQMessageSubscriberService, Monai.Deploy.Messaging.RabbitMQ",
+      "subscriberSettings": {
+        "endpoint": "localhost",
+        "username": "rabbitmq",
+        "password": "rabbitmq",
+        "virtualHost": "monaideploy",
+        "exchange": "monaideploy",
+        "deadLetterExchange": "monaideploy-dead-letter",
+        "deliveryLimit": 3,
+        "requeueDelay": 30
+      }
+    },
+    "storage": {
+      "localTemporaryStoragePath": "./payloads",
+      "remoteTemporaryStoragePath": "/incoming",
+      "bucketName": "monaideploy",
+      "storageRootPath": "/payloads",
+      "temporaryBucketName": "monaideploy",
+      "serviceAssemblyName": "Monai.Deploy.Storage.MinIO.MinIoStorageService, Monai.Deploy.Storage.MinIO",
+      "watermarkPercent": 75,
+      "reserveSpaceGB": 5,
+      "settings": {
+        "endpoint": "localhost:9000",
+        "accessKey": "minioadmin",
+        "accessToken": "minioadmin",
+        "securedConnection": false,
+        "region": "local",
+        "createBuckets": "monaideploy"
+      }
+    },
+    "hl7": {
+      "port": 2575,
+      "maximumNumberOfConnections": 10,
+      "clientTimeout": 60000,
+      "sendAck": true
+    }
   },
-  "MessageBrokerSettings": {
-    "endpoint": "$HOST_IP",
-    "username": "rabbitmq",
-    "password": "rabbitmq",
-    "virtualHost": "monaideploy",
-    "exchange": "monaideploy"
+  "Kestrel": {
+    "EndPoints": {
+      "Http": {
+        "Url": "http://+:5000"
+      }
+    }
   },
-  "StorageServiceSettings": {
-    "host": "$HOST_IP",
-    "port": 9000,
-    "accessKey": "minioadmin",
-    "accessToken": "minioadmin",
-    "storageServiceBucketName": "monaideploy"
-  },
-  "OrthancSettings": {
-    "Host": "$HOST_IP",
-    "dimsePort": 1114,
-    "dicomWebRoot": "http://$HOST_IP:8089/dicom-web/",
-    "dicomWebRootInternal": "http://orthanc:8089/dicom-web/",
-    "username": "monai",
-    "password": "monai!"
+  "AllowedHosts": "*",
+  "Cli": {
+    "Runner": "Docker",
+    "HostDataStorageMount": "~/.mig/data",
+    "HostPlugInsStorageMount": "~/.mig/plug-ins",
+    "HostDatabaseStorageMount": "~/.mig/database",
+    "HostLogsStorageMount": "~/.mig/logs",
+    "InformaticsGatewayServerEndpoint": "http://localhost:5000",
+    "DockerImagePrefix": "ghcr.io/project-monai/monai-deploy-informatics-gateway"
   }
 }


### PR DESCRIPTION
### Description

- Changes made to make running integration test easier without using bash script.
- Enables running integration test within VS Test Explorer (with all 3rd party services running as provided in the docker-compose template).

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] I have updated the changelog
