### PR TITLE
Fix payload assembler not respecting user configured timeout window

### DIFF
--- a/tests/Integration.Test/Common/Assertions.cs
+++ b/tests/Integration.Test/Common/Assertions.cs
@@ -199,7 +199,15 @@ namespace Monai.Deploy.InformaticsGateway.Integration.Test.Common
                 message.ApplicationId.Should().Be(MessageBrokerConfiguration.InformaticsGatewayApplicationId);
                 var request = message.ConvertTo<WorkflowRequestEvent>();
                 request.Should().NotBeNull();
-                request.FileCount.Should().Be((dataProvider.DicomSpecs.NumberOfExpectedFiles(dataProvider.StudyGrouping)));
+
+                if (dataProvider.ClientSendOverAssociations == 1 || messages.Count == 1)
+                {
+                    request.FileCount.Should().Be((dataProvider.DicomSpecs.NumberOfExpectedFiles(dataProvider.StudyGrouping)));
+                }
+                else
+                {
+                    request.FileCount.Should().Be(dataProvider.DicomSpecs.FileCount / dataProvider.ClientSendOverAssociations);
+                }
 
                 if (dataProvider.Workflows is not null)
                 {

--- a/tests/Integration.Test/Common/DataProvider.cs
+++ b/tests/Integration.Test/Common/DataProvider.cs
@@ -38,6 +38,9 @@ namespace Monai.Deploy.InformaticsGateway.Integration.Test.Common
         public DicomStatus DimseRsponse { get; internal set; }
         public string StudyGrouping { get; internal set; }
         public string[] Workflows { get; internal set; } = null;
+        public int ClientTimeout { get; internal set; }
+        public int ClientAssociationPulseTime { get; internal set; } = 0;
+        public int ClientSendOverAssociations { get; internal set; } = 1;
 
         public DataProvider(Configurations configurations, ISpecFlowOutputHelper outputHelper)
         {

--- a/tests/Integration.Test/Features/AcrApi.feature
+++ b/tests/Integration.Test/Features/AcrApi.feature
@@ -28,7 +28,7 @@ Feature: ACR API
         Given a DICOM study on a remote DICOMweb service
         And an ACR API request to query & retrieve by <requestType>
         When the ACR API request is sent
-        Then a workflow requests sent to the message broker
+        Then a single workflow request is sent to the message broker
         And a study is uploaded to the storage service
 
     Examples:

--- a/tests/Integration.Test/Features/DicomDimseScp.feature
+++ b/tests/Integration.Test/Features/DicomDimseScp.feature
@@ -84,5 +84,5 @@ Feature: DICOM DIMSE SCP Services
 
         Examples:
             | modality | study_count | series_count | seconds | workflow_requests |
-            | MG       | 1           | 3            | 1       | 1                 |
+            | MG       | 1           | 3            | 3       | 1                 |
             | MG       | 1           | 3            | 6       | 3                 |

--- a/tests/Integration.Test/Features/DicomDimseScp.feature
+++ b/tests/Integration.Test/Features/DicomDimseScp.feature
@@ -31,14 +31,17 @@ Feature: DICOM DIMSE SCP Services
 
     Scenario: Response to C-ECHO-RQ
         Given a called AE Title named 'C-ECHO-TEST' that groups by '0020,000D' for 5 seconds
-        When a C-ECHO-RQ is sent to 'C-ECHO-TEST' from 'TEST-RUNNER' with timeout of 30 seconds
+        And a DICOM client configured with 30 seconds timeout
+        When a C-ECHO-RQ is sent to 'C-ECHO-TEST' from 'TEST-RUNNER'
         Then a successful response should be received
 
     @messaging_workflow_request @messaging
     Scenario Outline: Respond to C-STORE-RQ and group data by Study Instance UID
         Given a called AE Title named 'C-STORE-STUDY' that groups by '0020,000D' for 3 seconds
+        And a DICOM client configured with 300 seconds timeout
+        And a DICOM client configured to send data over 1 associations and wait 0 between each association
         And <count> <modality> studies
-        When a C-STORE-RQ is sent to 'Informatics Gateway' with AET 'C-STORE-STUDY' from 'TEST-RUNNER' with timeout of 300 seconds
+        When a C-STORE-RQ is sent to 'Informatics Gateway' with AET 'C-STORE-STUDY' from 'TEST-RUNNER'
         Then a successful response should be received
         And <count> workflow requests sent to message broker
         And studies are uploaded to storage service
@@ -53,8 +56,10 @@ Feature: DICOM DIMSE SCP Services
     @messaging_workflow_request @messaging
     Scenario Outline: Respond to C-STORE-RQ and group data by Series Instance UID
         Given a called AE Title named 'C-STORE-SERIES' that groups by '0020,000E' for 3 seconds
+        And a DICOM client configured with 300 seconds timeout
+        And a DICOM client configured to send data over 1 associations and wait 0 between each association
         And <study_count> <modality> studies with <series_count> series per study
-        When a C-STORE-RQ is sent to 'Informatics Gateway' with AET 'C-STORE-SERIES' from 'TEST-RUNNER' with timeout of 300 seconds
+        When a C-STORE-RQ is sent to 'Informatics Gateway' with AET 'C-STORE-SERIES' from 'TEST-RUNNER'
         Then a successful response should be received
         And <series_count> workflow requests sent to message broker
         And studies are uploaded to storage service
@@ -65,3 +70,19 @@ Feature: DICOM DIMSE SCP Services
             | CT       | 1           | 2            |
             | MG       | 1           | 3            |
             | US       | 1           | 2            |
+            
+    @messaging_workflow_request @messaging
+    Scenario Outline: Respond to C-STORE-RQ and group data by Study Instance UID over multiple associations
+        Given a called AE Title named 'C-STORE-STUDY' that groups by '0020,000D' for 5 seconds
+        And a DICOM client configured with 300 seconds timeout
+        And a DICOM client configured to send data over <series_count> associations and wait <seconds> between each association
+        And <study_count> <modality> studies with <series_count> series per study
+        When C-STORE-RQ are sent to 'Informatics Gateway' with AET 'C-STORE-STUDY' from 'TEST-RUNNER'
+        Then a successful response should be received
+        And <workflow_requests> workflow requests sent to message broker
+        And studies are uploaded to storage service
+
+        Examples:
+            | modality | study_count | series_count | seconds | workflow_requests |
+            | MG       | 1           | 3            | 1       | 1                 |
+            | MG       | 1           | 3            | 6       | 3                 |

--- a/tests/Integration.Test/StepDefinitions/DicomWebStowServiceStepDefinitions.cs
+++ b/tests/Integration.Test/StepDefinitions/DicomWebStowServiceStepDefinitions.cs
@@ -51,7 +51,7 @@ namespace Monai.Deploy.InformaticsGateway.Integration.Test.StepDefinitions
 
             _dataProvider.GenerateDicomData(modality, studyCount);
             _dataProvider.StudyGrouping = grouping;
-            _receivedMessages.SetupMessageHandle(_dataProvider.DicomSpecs.NumberOfExpectedRequests(grouping));
+            _receivedMessages.ClearMessages();
         }
 
         [Given(@"a workflow named '(.*)'")]

--- a/tests/Integration.Test/StepDefinitions/ExportServicesStepDefinitions.cs
+++ b/tests/Integration.Test/StepDefinitions/ExportServicesStepDefinitions.cs
@@ -132,14 +132,14 @@ namespace Monai.Deploy.InformaticsGateway.Integration.Test.StepDefinitions
                 exportRequestEvent.CorrelationId,
                 string.Empty);
 
-            _receivedMessages.SetupMessageHandle(1);
+            _receivedMessages.ClearMessages();
             _messagePublisher.Publish(routingKey, message.ToMessage());
         }
 
         [Then(@"Informatics Gateway exports the studies to the DICOM SCP")]
         public async Task ThenExportTheInstancesToTheDicomScp()
         {
-            _receivedMessages.MessageWaitHandle.Wait(DicomScpWaitTimeSpan).Should().BeTrue();
+            (await _receivedMessages.WaitforAsync(1, DicomScpWaitTimeSpan)).Should().BeTrue();
 
             foreach (var key in _dataProvider.DicomSpecs.FileHashes.Keys)
             {
@@ -151,7 +151,7 @@ namespace Monai.Deploy.InformaticsGateway.Integration.Test.StepDefinitions
         [Then(@"Informatics Gateway exports the studies to Orthanc")]
         public async Task ThenExportTheInstancesToOrthanc()
         {
-            _receivedMessages.MessageWaitHandle.Wait(DicomScpWaitTimeSpan).Should().BeTrue();
+            (await _receivedMessages.WaitforAsync(1, DicomScpWaitTimeSpan)).Should().BeTrue();
             var httpClient = new HttpClient();
             var dicomWebClient = new DicomWebClient(httpClient, null);
             dicomWebClient.ConfigureServiceUris(new Uri(_configuration.OrthancOptions.DicomWebRoot));

--- a/tests/Integration.Test/StepDefinitions/FhirDefinitions.cs
+++ b/tests/Integration.Test/StepDefinitions/FhirDefinitions.cs
@@ -57,7 +57,7 @@ namespace Monai.Deploy.InformaticsGateway.Integration.Test.StepDefinitions
             Guard.Against.NullOrWhiteSpace(format);
 
             await _dataProvider.GenerateFhirMessages(version, format);
-            _receivedMessages.SetupMessageHandle(_dataProvider.FhirSpecs.Files.Count);
+            _receivedMessages.ClearMessages();
         }
 
         [When(@"the FHIR messages are sent to Informatics Gateway")]
@@ -67,9 +67,9 @@ namespace Monai.Deploy.InformaticsGateway.Integration.Test.StepDefinitions
         }
 
         [Then(@"workflow requests are sent to message broker")]
-        public void ThenWorkflowRequestAreSentToMessageBroker()
+        public async Task ThenWorkflowRequestAreSentToMessageBrokerAsync()
         {
-            _receivedMessages.MessageWaitHandle.Wait(WaitTimeSpan).Should().BeTrue();
+            (await _receivedMessages.WaitforAsync(_dataProvider.FhirSpecs.Files.Count, WaitTimeSpan)).Should().BeTrue();
         }
 
         [Then(@"FHIR resources are uploaded to storage service")]

--- a/tests/Integration.Test/StepDefinitions/HealthLevel7Definitions.cs
+++ b/tests/Integration.Test/StepDefinitions/HealthLevel7Definitions.cs
@@ -49,7 +49,7 @@ namespace Monai.Deploy.InformaticsGateway.Integration.Test.StepDefinitions
         {
             Guard.Against.NullOrWhiteSpace(version);
             await _dataProvider.GenerateHl7Messages(version);
-            _receivedMessages.SetupMessageHandle(1);
+            _receivedMessages.ClearMessages();
         }
 
         [When(@"the message are sent to Informatics Gateway")]
@@ -71,9 +71,9 @@ namespace Monai.Deploy.InformaticsGateway.Integration.Test.StepDefinitions
         }
 
         [Then(@"a workflow requests sent to message broker")]
-        public void ThenAWorkflowRequestIsSentToMessageBroker()
+        public async Task ThenAWorkflowRequestIsSentToMessageBrokerAsync()
         {
-            _receivedMessages.MessageWaitHandle.Wait(WaitTimeSpan).Should().BeTrue();
+            (await _receivedMessages.WaitforAsync(_dataProvider.HL7Specs.Files.Count, WaitTimeSpan)).Should().BeTrue();
         }
 
         [Then(@"messages are uploaded to storage service")]

--- a/tests/Integration.Test/StepDefinitions/SharedDefinitions.cs
+++ b/tests/Integration.Test/StepDefinitions/SharedDefinitions.cs
@@ -53,22 +53,21 @@ namespace Monai.Deploy.InformaticsGateway.Integration.Test.StepDefinitions
 
             _dataProvider.GenerateDicomData(modality, studyCount);
 
-            _receivedMessages.SetupMessageHandle(_dataProvider.DicomSpecs.NumberOfExpectedRequests(_dataProvider.StudyGrouping));
+            _receivedMessages.ClearMessages();
         }
 
         [Then(@"(.*) workflow requests sent to message broker")]
-        public void ThenWorkflowRequestSentToMessageBroker(int workflowCount)
+        public async Task ThenWorkflowRequestSentToMessageBrokerAsync(int workflowCount)
         {
             Guard.Against.NegativeOrZero(workflowCount);
 
-            _receivedMessages.MessageWaitHandle.Wait(MessageWaitTimeSpan).Should().BeTrue();
+            (await _receivedMessages.WaitforAsync(workflowCount, MessageWaitTimeSpan)).Should().BeTrue();
             _assertions.ShouldHaveCorrectNumberOfWorkflowRequestMessages(_dataProvider, _receivedMessages.Messages, workflowCount);
         }
 
         [Then(@"studies are uploaded to storage service")]
         public async Task ThenXXFilesUploadedToStorageService()
         {
-            _receivedMessages.MessageWaitHandle.Wait(MessageWaitTimeSpan).Should().BeTrue();
             await _assertions.ShouldHaveUploadedDicomDataToMinio(_receivedMessages.Messages, _dataProvider.DicomSpecs.FileHashes);
         }
     }


### PR DESCRIPTION
### Description

Fixes a regression where the payload assembler is not waiting for the timeout associated with the AE title.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] I have updated the changelog
