### PR TITLE
Spawn new thread for processing echo requests

### DIFF
--- a/src/InformaticsGateway/Services/Http/DestinationAeTitleController.cs
+++ b/src/InformaticsGateway/Services/Http/DestinationAeTitleController.cs
@@ -115,7 +115,14 @@ namespace Monai.Deploy.InformaticsGateway.Services.Http
                     return NotFound();
                 }
 
-                var request = new ScuWorkRequest(traceId, RequestType.CEcho, destinationApplicationEntity.HostIp, destinationApplicationEntity.Port, destinationApplicationEntity.AeTitle);
+                var request = new ScuWorkRequest(
+                    traceId,
+                    RequestType.CEcho,
+                    destinationApplicationEntity.HostIp,
+                    destinationApplicationEntity.Port,
+                    destinationApplicationEntity.AeTitle,
+                    HttpContext.RequestAborted
+                );
                 var response = await _scuQueue.Queue(request, HttpContext.RequestAborted).ConfigureAwait(false);
 
                 if (response.Status != ResponseStatus.Success)

--- a/src/InformaticsGateway/Services/Scu/ScuWorkRequest.cs
+++ b/src/InformaticsGateway/Services/Scu/ScuWorkRequest.cs
@@ -33,8 +33,9 @@ namespace Monai.Deploy.InformaticsGateway.Services.Scu
         public string HostIp { get; }
         public int Port { get; }
         public string AeTitle { get; }
+        public CancellationToken CancellationToken { get; }
 
-        public ScuWorkRequest(string correlationId, RequestType requestType, string hostIp, int port, string aeTitle)
+        public ScuWorkRequest(string correlationId, RequestType requestType, string hostIp, int port, string aeTitle, CancellationToken cancellationToken)
         {
             Guard.Against.NullOrWhiteSpace(correlationId);
             Guard.Against.NullOrWhiteSpace(hostIp);
@@ -45,6 +46,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Scu
             HostIp = hostIp;
             Port = port;
             AeTitle = aeTitle;
+            CancellationToken = cancellationToken;
 
             _awaiter = new AsyncManualResetEvent(false);
         }

--- a/src/InformaticsGateway/Test/Services/Scu/ScuServiceTest.cs
+++ b/src/InformaticsGateway/Test/Services/Scu/ScuServiceTest.cs
@@ -96,7 +96,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Scu
 
             Assert.Equal(ServiceStatus.Running, svc.Status);
 
-            var request = new ScuWorkRequest(Guid.NewGuid().ToString(), RequestType.CEcho, "localhost", _port, DicomScpFixture.s_aETITLE);
+            var request = new ScuWorkRequest(Guid.NewGuid().ToString(), RequestType.CEcho, "localhost", _port, DicomScpFixture.s_aETITLE, CancellationToken.None);
 
             var response = await _scuQueue.Queue(request, _cancellationTokenSource.Token);
 
@@ -113,7 +113,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Scu
 
             Assert.Equal(ServiceStatus.Running, svc.Status);
 
-            var request = new ScuWorkRequest(Guid.NewGuid().ToString(), RequestType.CEcho, "localhost", _port, "BADAET");
+            var request = new ScuWorkRequest(Guid.NewGuid().ToString(), RequestType.CEcho, "localhost", _port, "BADAET", CancellationToken.None);
 
             var response = await _scuQueue.Queue(request, _cancellationTokenSource.Token);
 
@@ -130,7 +130,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Scu
 
             Assert.Equal(ServiceStatus.Running, svc.Status);
 
-            var request = new ScuWorkRequest(Guid.NewGuid().ToString(), RequestType.CEcho, "localhost", _port, "ABORT");
+            var request = new ScuWorkRequest(Guid.NewGuid().ToString(), RequestType.CEcho, "localhost", _port, "ABORT", CancellationToken.None);
 
             var response = await _scuQueue.Queue(request, _cancellationTokenSource.Token);
 
@@ -147,7 +147,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Scu
 
             Assert.Equal(ServiceStatus.Running, svc.Status);
 
-            var request = new ScuWorkRequest(Guid.NewGuid().ToString(), RequestType.CEcho, "UNKNOWNHOST123456789", _port, DicomScpFixture.s_aETITLE);
+            var request = new ScuWorkRequest(Guid.NewGuid().ToString(), RequestType.CEcho, "UNKNOWNHOST123456789", _port, DicomScpFixture.s_aETITLE, CancellationToken.None);
 
             var response = await _scuQueue.Queue(request, _cancellationTokenSource.Token);
 


### PR DESCRIPTION
### Description

Currently, echo requests are blocking the `ScuService` thread allowing for only one request to be processed at a time. Long running requests (such as the ones failing to reach its target) will cause consecutive echo requests to be delayed, eventually resulting in timeouts. To avoid this, the PR makes a change to spawn a new thread for each call to `Process`.

This also adds a change that passes the `HttpContext.RequestAborted` cancellation token down the chain so that processing of echo requests could be cancelled if the http request is aborted.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] I have updated the changelog
