### PR TITLE
gh-418 Implement data input plug-in engine and integration with SCP service

### DIFF
--- a/docs/api/rest/config.md
+++ b/docs/api/rest/config.md
@@ -54,7 +54,11 @@ curl --location --request GET 'http://localhost:5000/config/ae'
     "grouping": "0020,000D",
     "timeout": 5,
     "ignoredSopClasses": ["1.2.840.10008.5.1.4.1.1.1.1"],
-    "allowedSopClasses": ["1.2.840.10008.5.1.4.1.1.1.2"]
+    "allowedSopClasses": ["1.2.840.10008.5.1.4.1.1.1.2"],
+    "pluginAssemblies": [
+        "Monai.Deploy.InformaticsGateway.Test.Plugins.TestInputDataPluginAddWorkflow, Monai.Deploy.InformaticsGateway.Test.Plugins",
+        "Monai.Deploy.InformaticsGateway.Test.Plugins.TestInputDataPluginModifyDicomFile, Monai.Deploy.InformaticsGateway.Test.Plugins"
+    ]
   },
   {
     "name": "liver-seg",
@@ -151,6 +155,10 @@ curl --location --request POST 'http://localhost:5000/config/ae/' \
             "timeout": 5,
             "workflows": [
                 "3f6a08a1-0dea-44e9-ab82-1ff1adf43a8e"
+            ],
+            "pluginAssemblies": [
+                "Monai.Deploy.InformaticsGateway.Test.Plugins.TestInputDataPluginAddWorkflow, Monai.Deploy.InformaticsGateway.Test.Plugins",
+                "Monai.Deploy.InformaticsGateway.Test.Plugins.TestInputDataPluginModifyDicomFile, Monai.Deploy.InformaticsGateway.Test.Plugins"
             ]
         }
     }'
@@ -162,7 +170,11 @@ curl --location --request POST 'http://localhost:5000/config/ae/' \
 {
   "name": "breast-tumor",
   "aeTitle": "BREASTV1",
-  "workflows": ["3f6a08a1-0dea-44e9-ab82-1ff1adf43a8e"]
+  "workflows": ["3f6a08a1-0dea-44e9-ab82-1ff1adf43a8e"],
+  "pluginAssemblies": [
+      "Monai.Deploy.InformaticsGateway.Test.Plugins.TestInputDataPluginAddWorkflow, Monai.Deploy.InformaticsGateway.Test.Plugins",
+      "Monai.Deploy.InformaticsGateway.Test.Plugins.TestInputDataPluginModifyDicomFile, Monai.Deploy.InformaticsGateway.Test.Plugins"
+  ]
 }
 ```
 
@@ -210,6 +222,10 @@ curl --location --request PUT 'http://localhost:5000/config/ae/' \
             "timeout": 3,
             "workflows": [
                 "3f6a08a1-0dea-44e9-ab82-1ff1adf43a8e"
+            ],
+            "pluginAssemblies": [
+                "Monai.Deploy.InformaticsGateway.Test.Plugins.TestInputDataPluginAddWorkflow, Monai.Deploy.InformaticsGateway.Test.Plugins",
+                "Monai.Deploy.InformaticsGateway.Test.Plugins.TestInputDataPluginModifyDicomFile, Monai.Deploy.InformaticsGateway.Test.Plugins"
             ]
         }
     }'
@@ -222,6 +238,10 @@ curl --location --request PUT 'http://localhost:5000/config/ae/' \
   "name": "breast-tumor",
   "aeTitle": "BREASTV1",
   "workflows": ["3f6a08a1-0dea-44e9-ab82-1ff1adf43a8e"],
+  "pluginAssemblies": [
+      "Monai.Deploy.InformaticsGateway.Test.Plugins.TestInputDataPluginAddWorkflow, Monai.Deploy.InformaticsGateway.Test.Plugins",
+      "Monai.Deploy.InformaticsGateway.Test.Plugins.TestInputDataPluginModifyDicomFile, Monai.Deploy.InformaticsGateway.Test.Plugins"
+  ],
   "timeout": 3
 }
 ```

--- a/docs/setup/setup.md
+++ b/docs/setup/setup.md
@@ -311,6 +311,19 @@ mig-cli aet add -a BrainAET -grouping 0020,000E, -t 30
 The command creates a new listening AE Title with AE Title `BrainAET`. The listening AE Title
 will group instances by the Series Instance UID (0020,000E) with a timeout value of 30 seconds.
 
+
+### Optional: Input Data Plug-ins
+
+Each listening AE Title may be configured with zero or more plug-ins to maniulate incoming DICOM files before saving to the storage
+service and dispatching a workflow request. To include input data plug-ins, first create your plug-ins by implementing the
+[IInputDataPlugin](xref:Monai.Deploy.InformaticsGateway.Api.IInputDataPlugin) interface and then use `-p` argument with the fully
+qualified type name with the `mig-cli aet add` command. For example, the following command adds `MyNamespace.AnonymizePlugin`
+and `MyNamespace.FixSeriesData` plug-ins from the `MyNamespace.Plugins` assembly file.
+
+```bash
+mig-cli aet add -a BrainAET -grouping 0020,000E, -t 30 -p "MyNamespace.AnonymizePlugin, MyNamespace.Plugins" "MyNamespace.FixSeriesData, MyNamespace.Plugins"
+```
+
 > [!Note]
 > `-grouping` is optional, with a default value of 0020,000D.
 > `-t` is optional, with a default value of 5 seconds.

--- a/src/Api/IInputDataPlugin.cs
+++ b/src/Api/IInputDataPlugin.cs
@@ -1,0 +1,32 @@
+﻿/*
+ * Copyright 2023 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Threading.Tasks;
+using FellowOakDicom;
+using Monai.Deploy.InformaticsGateway.Api.Storage;
+
+namespace Monai.Deploy.InformaticsGateway.Api
+{
+    /// <summary>
+    /// <c>IInputDataPlugin</c> enables lightweight data processing over incoming data received from supported data ingestion
+    /// services.
+    /// Refer to <see cref="IInputDataPluginEngine" /> for additional details.
+    /// </summary>
+    public interface IInputDataPlugin
+    {
+        Task<(DicomFile dicomFile, FileStorageMetadata fileMetadata)> Execute(DicomFile dicomFile, FileStorageMetadata fileMetadata);
+    }
+}

--- a/src/Api/IInputDataPluginEngine.cs
+++ b/src/Api/IInputDataPluginEngine.cs
@@ -1,0 +1,40 @@
+﻿/*
+ * Copyright 2023 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FellowOakDicom;
+using Monai.Deploy.InformaticsGateway.Api.Storage;
+
+namespace Monai.Deploy.InformaticsGateway.Api
+{
+    /// <summary>
+    /// <c>IInputDataPluginEngine</c> processes incoming data receivied from various supported services through
+    /// a list of plug-ins based on <see cref="IInputDataPlugin"/>.
+    /// Rules:
+    /// <list type="bullet">
+    /// <item>A list of plug-ins can be included with each export request, and each plug-in is executed in the order stored, processing one file at a time, enabling piping of the data before each file is exported.</item>
+    /// <item>Plugins MUST be lightweight and not hinder the export process</item>
+    /// <item>Plugins SHALL not accumulate files in memory or storage for bulk processing</item>
+    /// </list>
+    /// </summary>
+    public interface IInputDataPluginEngine
+    {
+        void Configure(IReadOnlyList<string> pluginAssemblies);
+
+        Task<(DicomFile dicomFile, FileStorageMetadata fileMetadata)> ExecutePlugins(DicomFile dicomFile, FileStorageMetadata fileMetadata);
+    }
+}

--- a/src/Api/MonaiApplicationEntity.cs
+++ b/src/Api/MonaiApplicationEntity.cs
@@ -72,6 +72,9 @@ namespace Monai.Deploy.InformaticsGateway.Api
         /// </summary>
         public List<string> Workflows { get; set; } = default!;
 
+        /// <summary>
+        /// Optional list of data input plug-in type names to be executed by the <see cref="IInputDataPluginEngine"/>.
+        /// </summary>
         public List<string> PluginAssemblies { get; set; } = default!;
 
         /// <summary>

--- a/src/Api/MonaiApplicationEntity.cs
+++ b/src/Api/MonaiApplicationEntity.cs
@@ -72,6 +72,8 @@ namespace Monai.Deploy.InformaticsGateway.Api
         /// </summary>
         public List<string> Workflows { get; set; } = default!;
 
+        public List<string> PluginAssemblies { get; set; } = default!;
+
         /// <summary>
         /// Optional field to specify SOP Class UIDs to ignore.
         /// <see cref="IgnoredSopClasses"/> and <see cref="AllowedSopClasses"/> are mutually exclusive.
@@ -128,6 +130,8 @@ namespace Monai.Deploy.InformaticsGateway.Api
             IgnoredSopClasses ??= new List<string>();
 
             AllowedSopClasses ??= new List<string>();
+
+            PluginAssemblies ??= new List<string>();
         }
 
         public override string ToString()

--- a/src/CLI/Commands/AetCommand.cs
+++ b/src/CLI/Commands/AetCommand.cs
@@ -97,6 +97,12 @@ namespace Monai.Deploy.InformaticsGateway.CLI
                 IsRequired = false,
             };
             addCommand.AddOption(allowedSopsOption);
+            var plugins = new Option<List<string>>(new string[] { "-p", "--plugins" }, description: "A space separated list of fully qualified type names of the plug-ins (surround each plug-in with double quotes)")
+            {
+                AllowMultipleArgumentsPerToken = true,
+                IsRequired = false,
+            };
+            addCommand.AddOption(plugins);
 
             addCommand.Handler = CommandHandler.Create<MonaiApplicationEntity, IHost, bool, CancellationToken>(AddAeTitlehandlerAsync);
         }
@@ -130,6 +136,12 @@ namespace Monai.Deploy.InformaticsGateway.CLI
                 IsRequired = false,
             };
             addCommand.AddOption(allowedSopsOption);
+            var plugins = new Option<List<string>>(new string[] { "-p", "--plugins" }, description: "A space separated list of fully qualified type names of the plug-ins (surround each plug-in with double quotes)")
+            {
+                AllowMultipleArgumentsPerToken = true,
+                IsRequired = false,
+            };
+            addCommand.AddOption(plugins);
 
             addCommand.Handler = CommandHandler.Create<MonaiApplicationEntity, IHost, bool, CancellationToken>(EditAeTitleHandlerAsync);
         }
@@ -274,8 +286,7 @@ namespace Monai.Deploy.InformaticsGateway.CLI
                 }
                 if (result.AllowedSopClasses.Any())
                 {
-                    logger.MonaiAeAllowedSops(string.Join(',', result.AllowedSopClasses));
-                    logger.AcceptedSopClassesWarning();
+                    logger.MonaiAePlugins(string.Join(',', result.AllowedSopClasses));
                 }
             }
             catch (ConfigurationException ex)
@@ -329,6 +340,10 @@ namespace Monai.Deploy.InformaticsGateway.CLI
                 {
                     logger.MonaiAeAllowedSops(string.Join(',', result.AllowedSopClasses));
                     logger.AcceptedSopClassesWarning();
+                }
+                if (result.AllowedSopClasses.Any())
+                {
+                    logger.MonaiAePlugins(string.Join(',', result.AllowedSopClasses));
                 }
             }
             catch (ConfigurationException ex)

--- a/src/CLI/Logging/Log.cs
+++ b/src/CLI/Logging/Log.cs
@@ -187,6 +187,9 @@ namespace Monai.Deploy.InformaticsGateway.CLI
         [LoggerMessage(EventId = 30061, Level = LogLevel.Critical, Message = "Error updating SCP Application Entity {aeTitle}: {message}")]
         public static partial void ErrorUpdatingMonaiApplicationEntity(this ILogger logger, string aeTitle, string message);
 
+        [LoggerMessage(EventId = 30062, Level = LogLevel.Information, Message = "\tPlug-ins: {plugins}")]
+        public static partial void MonaiAePlugins(this ILogger logger, string plugins);
+
         // Docker Runner
         [LoggerMessage(EventId = 31000, Level = LogLevel.Debug, Message = "Checking for existing {applicationName} ({version}) containers...")]
         public static partial void CheckingExistingAppContainer(this ILogger logger, string applicationName, string version);

--- a/src/Database/EntityFramework/Configuration/MonaiApplicationEntityConfiguration.cs
+++ b/src/Database/EntityFramework/Configuration/MonaiApplicationEntityConfiguration.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 MONAI Consortium
+ * Copyright 2021-2023 MONAI Consortium
  * Copyright 2021 NVIDIA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,7 @@ using Monai.Deploy.InformaticsGateway.Api;
 namespace Monai.Deploy.InformaticsGateway.Database.EntityFramework.Configuration
 {
 #pragma warning disable CS8604, CS8603
+
     internal class MonaiApplicationEntityConfiguration : IEntityTypeConfiguration<MonaiApplicationEntity>
     {
         public void Configure(EntityTypeBuilder<MonaiApplicationEntity> builder)
@@ -51,6 +52,11 @@ namespace Monai.Deploy.InformaticsGateway.Database.EntityFramework.Configuration
                         v => JsonSerializer.Serialize(v, jsonSerializerSettings),
                         v => JsonSerializer.Deserialize<List<string>>(v, jsonSerializerSettings))
                 .Metadata.SetValueComparer(valueComparer);
+            builder.Property(j => j.PluginAssemblies)
+                .HasConversion(
+                        v => JsonSerializer.Serialize(v, jsonSerializerSettings),
+                        v => JsonSerializer.Deserialize<List<string>>(v, jsonSerializerSettings))
+                .Metadata.SetValueComparer(valueComparer);
             builder.Property(j => j.IgnoredSopClasses)
                 .HasConversion(
                         v => JsonSerializer.Serialize(v, jsonSerializerSettings),
@@ -67,5 +73,6 @@ namespace Monai.Deploy.InformaticsGateway.Database.EntityFramework.Configuration
             builder.Ignore(p => p.Id);
         }
     }
+
 #pragma warning restore CS8604, CS8603
 }

--- a/src/Database/EntityFramework/Migrations/20230802003305_R4_0.4.0.Designer.cs
+++ b/src/Database/EntityFramework/Migrations/20230802003305_R4_0.4.0.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Monai.Deploy.InformaticsGateway.Database.EntityFramework;
 
@@ -10,9 +11,10 @@ using Monai.Deploy.InformaticsGateway.Database.EntityFramework;
 namespace Monai.Deploy.InformaticsGateway.Database.Migrations
 {
     [DbContext(typeof(InformaticsGatewayContext))]
-    partial class InformaticsGatewayContextModelSnapshot : ModelSnapshot
+    [Migration("20230802003305_R4_0.4.0")]
+    partial class R4_040
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.15");

--- a/src/Database/EntityFramework/Migrations/20230802003305_R4_0.4.0.cs
+++ b/src/Database/EntityFramework/Migrations/20230802003305_R4_0.4.0.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Monai.Deploy.InformaticsGateway.Database.Migrations
+{
+    public partial class R4_040 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PluginAssemblies",
+                table: "MonaiApplicationEntities",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PluginAssemblies",
+                table: "MonaiApplicationEntities");
+        }
+    }
+}

--- a/src/Database/EntityFramework/Test/MonaiApplicationEntityRepositoryTest.cs
+++ b/src/Database/EntityFramework/Test/MonaiApplicationEntityRepositoryTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright 2022 MONAI Consortium
+ * Copyright 2022-2023 MONAI Consortium
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,8 @@ namespace Monai.Deploy.InformaticsGateway.Database.EntityFramework.Test
                 AllowedSopClasses = new List<string> { "1", "2", "3" },
                 Workflows = new List<string> { "W1", "W2" },
                 Grouping = "G",
-                IgnoredSopClasses = new List<string> { "4", "5" }
+                IgnoredSopClasses = new List<string> { "4", "5" },
+                PluginAssemblies = new List<string> { "AssemblyA", "AssemblyB", "AssemblyC" },
             };
 
             var store = new MonaiApplicationEntityRepository(_serviceScopeFactory.Object, _logger.Object, _options);
@@ -132,7 +133,7 @@ namespace Monai.Deploy.InformaticsGateway.Database.EntityFramework.Test
         }
 
         [Fact]
-        public async Task GivenDestinationApplicationEntitiesInTheDatabase_WhenToListIsCalled_ExpectAllEntitiesToBeReturned()
+        public async Task GivenMonaiApplicationEntitiesInTheDatabase_WhenToListIsCalled_ExpectAllEntitiesToBeReturned()
         {
             var store = new MonaiApplicationEntityRepository(_serviceScopeFactory.Object, _logger.Object, _options);
 

--- a/src/InformaticsGateway/Common/PlugingLoadingException.cs
+++ b/src/InformaticsGateway/Common/PlugingLoadingException.cs
@@ -1,0 +1,31 @@
+﻿/*
+ * Copyright 2023 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+
+namespace Monai.Deploy.InformaticsGateway.Common
+{
+    public class PlugingLoadingException : Exception
+    {
+        public PlugingLoadingException(string message) : base(message)
+        {
+        }
+
+        public PlugingLoadingException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/InformaticsGateway/Common/SR.cs
+++ b/src/InformaticsGateway/Common/SR.cs
@@ -1,0 +1,27 @@
+﻿/*
+ * Copyright 2023 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.IO;
+using System;
+
+namespace Monai.Deploy.InformaticsGateway.Common
+{
+    internal static class SR
+    {
+        public const string PlugInDirectoryName = "plug-ins";
+        public static readonly string PlugInDirectoryPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, SR.PlugInDirectoryName);
+    }
+}

--- a/src/InformaticsGateway/Common/TypeExtensions.cs
+++ b/src/InformaticsGateway/Common/TypeExtensions.cs
@@ -1,0 +1,77 @@
+﻿/*
+ * Copyright 2022-2023 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Ardalis.GuardClauses;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Monai.Deploy.InformaticsGateway.Common
+{
+    public static class TypeExtensions
+    {
+        public static T CreateInstance<T>(this Type type, IServiceProvider serviceProvider, params object[] parameters)
+        {
+            Guard.Against.Null(type, nameof(type));
+            Guard.Against.Null(serviceProvider, nameof(serviceProvider));
+
+            return (T)ActivatorUtilities.CreateInstance(serviceProvider, type, parameters);
+        }
+
+        public static T CreateInstance<T>(this Type interfaceType, IServiceProvider serviceProvider, string typeString, params object[] parameters)
+        {
+            Guard.Against.Null(interfaceType, nameof(interfaceType));
+            Guard.Against.Null(serviceProvider, nameof(serviceProvider));
+            Guard.Against.NullOrWhiteSpace(typeString, nameof(typeString));
+
+            var type = interfaceType.GetType(typeString);
+            var processor = ActivatorUtilities.CreateInstance(serviceProvider, type, parameters);
+
+            return (T)processor;
+        }
+
+        public static Type GetType(this Type interfaceType, string typeString)
+        {
+            Guard.Against.Null(interfaceType, nameof(interfaceType));
+            Guard.Against.NullOrWhiteSpace(typeString, nameof(typeString));
+
+            var type = Type.GetType(
+                      typeString,
+                      (name) =>
+                      {
+                          var assembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(z => !string.IsNullOrWhiteSpace(z.FullName) && z.FullName.StartsWith(name.FullName));
+
+                          assembly ??= Assembly.LoadFile(Path.Combine(SR.PlugInDirectoryPath, $"{name.Name}.dll"));
+
+                          return assembly;
+                      },
+                      null,
+                      true);
+
+            if (type is not null &&
+                (type.IsSubclassOf(interfaceType) ||
+                (type.BaseType is not null && type.BaseType.IsAssignableTo(interfaceType)) ||
+                (type.GetInterfaces().Contains(interfaceType))))
+            {
+                return type;
+            }
+
+            throw new NotSupportedException($"{typeString} is not a sub-type of {interfaceType.Name}");
+        }
+    }
+}

--- a/src/InformaticsGateway/Program.cs
+++ b/src/InformaticsGateway/Program.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 MONAI Consortium
+ * Copyright 2021-2023 MONAI Consortium
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Monai.Deploy.InformaticsGateway.Api;
 using Monai.Deploy.InformaticsGateway.Common;
 using Monai.Deploy.InformaticsGateway.Configuration;
 using Monai.Deploy.InformaticsGateway.Database;
@@ -111,6 +112,7 @@ namespace Monai.Deploy.InformaticsGateway
 
                     services.AddScoped<IPayloadMoveActionHandler, PayloadMoveActionHandler>();
                     services.AddScoped<IPayloadNotificationActionHandler, PayloadNotificationActionHandler>();
+                    services.AddScoped<IInputDataPluginEngine, InputDataPluginEngine>();
 
                     services.AddMonaiDeployStorageService(hostContext.Configuration.GetSection("InformaticsGateway:storage:serviceAssemblyName").Value, Monai.Deploy.Storage.HealthCheckOptions.ServiceHealthCheck);
 

--- a/src/InformaticsGateway/Services/Common/InputDataPluginEngine.cs
+++ b/src/InformaticsGateway/Services/Common/InputDataPluginEngine.cs
@@ -1,0 +1,85 @@
+﻿/*
+ * Copyright 2023 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FellowOakDicom;
+using Microsoft.Extensions.Logging;
+using Monai.Deploy.InformaticsGateway.Api;
+using Monai.Deploy.InformaticsGateway.Api.Storage;
+using Monai.Deploy.InformaticsGateway.Common;
+
+namespace Monai.Deploy.InformaticsGateway.Services.Common
+{
+    internal class InputDataPluginEngine : IInputDataPluginEngine
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ILogger<InputDataPluginEngine> _logger;
+        private IReadOnlyList<IInputDataPlugin> _plugsins;
+
+        public InputDataPluginEngine(IServiceProvider serviceProvider, ILogger<InputDataPluginEngine> logger)
+        {
+            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public void Configure(IReadOnlyList<string> pluginAssemblies)
+        {
+            _plugsins = LoadPlugins(_serviceProvider, pluginAssemblies);
+        }
+
+        public async Task<(DicomFile dicomFile, FileStorageMetadata fileMetadata)> ExecutePlugins(DicomFile dicomFile, FileStorageMetadata fileMetadata)
+        {
+            if (_plugsins == null)
+            {
+                throw new ApplicationException("InputDataPluginEngine not configured, please call Configure() first.");
+            }
+
+            foreach (var plugin in _plugsins)
+            {
+                (dicomFile, fileMetadata) = await plugin.Execute(dicomFile, fileMetadata).ConfigureAwait(false);
+            }
+
+            return (dicomFile, fileMetadata);
+        }
+
+        private static IReadOnlyList<IInputDataPlugin> LoadPlugins(IServiceProvider serviceProvider, IReadOnlyList<string> pluginAssemblies)
+        {
+            var exceptions = new List<Exception>();
+            var list = new List<IInputDataPlugin>();
+            foreach (var plugin in pluginAssemblies)
+            {
+                try
+                {
+                    list.Add(typeof(IInputDataPlugin).CreateInstance<IInputDataPlugin>(serviceProvider, typeString: plugin));
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(new PlugingLoadingException($"Error loading plug-in '{plugin}'.", ex));
+                }
+            }
+
+            if (exceptions.Any())
+            {
+                throw new AggregateException("Error loading plug-in(s).", exceptions);
+            }
+
+            return list;
+        }
+    }
+}

--- a/src/InformaticsGateway/Services/Scu/ScuService.cs
+++ b/src/InformaticsGateway/Services/Scu/ScuService.cs
@@ -56,7 +56,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Scu
             _workQueue = _scope.ServiceProvider.GetService<IScuQueue>() ?? throw new ServiceNotFoundException(nameof(IScuQueue));
         }
 
-        private async Task BackgroundProcessingAsync(CancellationToken cancellationToken)
+        private Task BackgroundProcessingAsync(CancellationToken cancellationToken)
         {
             _logger.ServiceRunning(ServiceName);
             while (!cancellationToken.IsCancellationRequested)
@@ -83,11 +83,12 @@ namespace Monai.Deploy.InformaticsGateway.Services.Scu
             }
             Status = ServiceStatus.Cancelled;
             _logger.ServiceCancelled(ServiceName);
+            return Task.CompletedTask;
         }
 
         private void ProcessThread(ScuWorkRequest request, CancellationToken cancellationToken)
         {
-            Task.Run(() => Process(request, cancellationToken));
+            Task.Run(() => Process(request, cancellationToken), cancellationToken);
         }
 
         private async Task Process(ScuWorkRequest request, CancellationToken cancellationToken)

--- a/src/InformaticsGateway/Services/Scu/ScuService.cs
+++ b/src/InformaticsGateway/Services/Scu/ScuService.cs
@@ -56,7 +56,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Scu
             _workQueue = _scope.ServiceProvider.GetService<IScuQueue>() ?? throw new ServiceNotFoundException(nameof(IScuQueue));
         }
 
-        private Task BackgroundProcessingAsync(CancellationToken cancellationToken)
+        private Task BackgroundProcessing(CancellationToken cancellationToken)
         {
             _logger.ServiceRunning(ServiceName);
             while (!cancellationToken.IsCancellationRequested)
@@ -201,7 +201,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Scu
         {
             var task = Task.Run(async () =>
             {
-                await BackgroundProcessingAsync(cancellationToken).ConfigureAwait(false);
+                await BackgroundProcessing(cancellationToken).ConfigureAwait(false);
             }, CancellationToken.None);
 
             Status = ServiceStatus.Running;

--- a/src/InformaticsGateway/Test/Monai.Deploy.InformaticsGateway.Test.csproj
+++ b/src/InformaticsGateway/Test/Monai.Deploy.InformaticsGateway.Test.csproj
@@ -1,5 +1,5 @@
 ﻿<!--
-  ~ Copyright 2021-2022 MONAI Consortium
+  ~ Copyright 2021-2023 MONAI Consortium
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@
     <ProjectReference Include="..\..\Api\Monai.Deploy.InformaticsGateway.Api.csproj" />
     <ProjectReference Include="..\..\Database\EntityFramework\Monai.Deploy.InformaticsGateway.Database.EntityFramework.csproj" />
     <ProjectReference Include="..\Monai.Deploy.InformaticsGateway.csproj" />
+    <ProjectReference Include="Plugins\Monai.Deploy.InformaticsGateway.Test.Plugins.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -61,4 +62,17 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Remove="Plugins\**" />
+    <EmbeddedResource Remove="Plugins\**" />
+    <None Remove="Plugins\**" />
+  </ItemGroup>
+
+  <Target Name="CopyPluginsBuild" AfterTargets="Build">
+    <ItemGroup>
+      <PluginDlls Include="$(OutDir)Monai.Deploy.InformaticsGateway.Test.Plugins.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(PluginDlls)" DestinationFolder="$(OutDir)\plug-ins\" SkipUnchangedFiles="true" />
+    <Message Text="Files copied successfully to $(OutDir)\plug-ins\." Importance="high" />
+  </Target>
 </Project>

--- a/src/InformaticsGateway/Test/Plugins/Monai.Deploy.InformaticsGateway.Test.Plugins.csproj
+++ b/src/InformaticsGateway/Test/Plugins/Monai.Deploy.InformaticsGateway.Test.Plugins.csproj
@@ -1,0 +1,29 @@
+<!--
+  ~ Copyright 2023 MONAI Consortium
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Api\Monai.Deploy.InformaticsGateway.Api.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/InformaticsGateway/Test/Plugins/TestInputDataPlugins.cs
+++ b/src/InformaticsGateway/Test/Plugins/TestInputDataPlugins.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * Copyright 2023 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using FellowOakDicom;
+using Monai.Deploy.InformaticsGateway.Api;
+using Monai.Deploy.InformaticsGateway.Api.Storage;
+
+namespace Monai.Deploy.InformaticsGateway.Test.Plugins
+{
+    public class TestInputDataPluginAddWorkflow : IInputDataPlugin
+    {
+        public static readonly string TestString = "TestInputDataPlugin executed!";
+
+        public Task<(DicomFile dicomFile, FileStorageMetadata fileMetadata)> Execute(DicomFile dicomFile, FileStorageMetadata fileMetadata)
+        {
+            fileMetadata.Workflows.Add(TestString);
+            return Task.FromResult((dicomFile, fileMetadata));
+        }
+    }
+
+    public class TestInputDataPluginModifyDicomFile : IInputDataPlugin
+    {
+        public static readonly DicomTag ExpectedTag = DicomTag.PatientAddress;
+        public static readonly string ExpectedValue = "Aborted by TestInputDataPluginModifyCorrelationId";
+
+        public Task<(DicomFile dicomFile, FileStorageMetadata fileMetadata)> Execute(DicomFile dicomFile, FileStorageMetadata fileMetadata)
+        {
+            dicomFile.Dataset.Add(ExpectedTag, ExpectedValue);
+            return Task.FromResult((dicomFile, fileMetadata));
+        }
+    }
+}

--- a/src/InformaticsGateway/Test/Services/Common/InputDataPluginEngineTest.cs
+++ b/src/InformaticsGateway/Test/Services/Common/InputDataPluginEngineTest.cs
@@ -1,0 +1,144 @@
+﻿/*
+ * Copyright 2023 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FellowOakDicom;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Monai.Deploy.InformaticsGateway.Api.Storage;
+using Monai.Deploy.InformaticsGateway.Common;
+using Monai.Deploy.InformaticsGateway.Services.Common;
+using Monai.Deploy.InformaticsGateway.Test.Plugins;
+using Moq;
+using Xunit;
+
+namespace Monai.Deploy.InformaticsGateway.Test.Services.Common
+{
+    public class InputDataPluginEngineTest
+    {
+        private readonly Mock<ILogger<InputDataPluginEngine>> _logger;
+        private readonly Mock<IServiceScopeFactory> _serviceScopeFactory;
+        private readonly Mock<IServiceScope> _serviceScope;
+        private readonly ServiceProvider _serviceProvider;
+
+        public InputDataPluginEngineTest()
+        {
+            _logger = new Mock<ILogger<InputDataPluginEngine>>();
+            _serviceScopeFactory = new Mock<IServiceScopeFactory>();
+            _serviceScope = new Mock<IServiceScope>();
+
+            var services = new ServiceCollection();
+            services.AddScoped(p => _logger.Object);
+
+            _serviceProvider = services.BuildServiceProvider();
+            _serviceScopeFactory.Setup(p => p.CreateScope()).Returns(_serviceScope.Object);
+            _serviceScope.Setup(p => p.ServiceProvider).Returns(_serviceProvider);
+
+            _logger.Setup(p => p.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+        }
+
+        [Fact]
+        public void GivenAnInputDataPluginEngine_WhenInitialized_ExpectParametersToBeValidated()
+        {
+            Assert.Throws<ArgumentNullException>(() => new InputDataPluginEngine(null, null));
+            Assert.Throws<ArgumentNullException>(() => new InputDataPluginEngine(_serviceProvider, null));
+
+            _ = new InputDataPluginEngine(_serviceProvider, _logger.Object);
+        }
+
+        [Fact]
+        public void GivenAnInputDataPluginEngine_WhenConfigureIsCalledWithBogusAssemblies_ThrowsException()
+        {
+            var pluginEngine = new InputDataPluginEngine(_serviceProvider, _logger.Object);
+            var assemblies = new List<string>() { "SomeBogusAssemblye" };
+
+            var exceptions = Assert.Throws<AggregateException>(() => pluginEngine.Configure(assemblies));
+
+            Assert.Single(exceptions.InnerExceptions);
+            Assert.True(exceptions.InnerException is PlugingLoadingException);
+            Assert.Contains("Error loading plug-in 'SomeBogusAssemblye'", exceptions.InnerException.Message);
+        }
+
+        [Fact]
+        public void GivenAnInputDataPluginEngine_WhenConfigureIsCalledWithAValidAssembly_ExpectNoExceptions()
+        {
+            var pluginEngine = new InputDataPluginEngine(_serviceProvider, _logger.Object);
+            var assemblies = new List<string>() { typeof(TestInputDataPluginAddWorkflow).AssemblyQualifiedName };
+
+            pluginEngine.Configure(assemblies);
+        }
+
+        [Fact]
+        public async Task GivenAnInputDataPluginEngine_WhenExecutePluginsIsCalledWithoutConfigure_ThrowsException()
+        {
+            var pluginEngine = new InputDataPluginEngine(_serviceProvider, _logger.Object);
+            var assemblies = new List<string>() { typeof(TestInputDataPluginAddWorkflow).AssemblyQualifiedName };
+
+            var dicomFile = GenerateDicomFile();
+            var dicomInfo = new DicomFileStorageMetadata(
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                dicomFile.Dataset.GetString(DicomTag.StudyInstanceUID),
+                dicomFile.Dataset.GetString(DicomTag.SeriesInstanceUID),
+                dicomFile.Dataset.GetString(DicomTag.SOPInstanceUID));
+
+            await Assert.ThrowsAsync<ApplicationException>(async () => await pluginEngine.ExecutePlugins(dicomFile, dicomInfo));
+        }
+
+        [Fact]
+        public async Task GivenAnInputDataPluginEngine_WhenExecutePluginsIsCalled_ExpectDataIsProcessedByPluginAsync()
+        {
+            var pluginEngine = new InputDataPluginEngine(_serviceProvider, _logger.Object);
+            var assemblies = new List<string>()
+            {
+                typeof(TestInputDataPluginAddWorkflow).AssemblyQualifiedName,
+                typeof(TestInputDataPluginModifyDicomFile).AssemblyQualifiedName
+            };
+
+            pluginEngine.Configure(assemblies);
+
+            var dicomFile = GenerateDicomFile();
+            var dicomInfo = new DicomFileStorageMetadata(
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                dicomFile.Dataset.GetString(DicomTag.StudyInstanceUID),
+                dicomFile.Dataset.GetString(DicomTag.SeriesInstanceUID),
+                dicomFile.Dataset.GetString(DicomTag.SOPInstanceUID));
+
+            var (resultDicomFile, resultDicomInfo) = await pluginEngine.ExecutePlugins(dicomFile, dicomInfo);
+
+            Assert.Equal(resultDicomFile, dicomFile);
+            Assert.Equal(resultDicomInfo, dicomInfo);
+            Assert.True(dicomInfo.Workflows.Contains(TestInputDataPluginAddWorkflow.TestString));
+            Assert.Equal(TestInputDataPluginModifyDicomFile.ExpectedValue, resultDicomFile.Dataset.GetString(TestInputDataPluginModifyDicomFile.ExpectedTag));
+        }
+
+        private static DicomFile GenerateDicomFile()
+        {
+            var dataset = new DicomDataset
+            {
+                { DicomTag.PatientID, "PID" },
+                { DicomTag.StudyInstanceUID, DicomUIDGenerator.GenerateDerivedFromUUID() },
+                { DicomTag.SeriesInstanceUID, DicomUIDGenerator.GenerateDerivedFromUUID() },
+                { DicomTag.SOPInstanceUID, DicomUIDGenerator.GenerateDerivedFromUUID() },
+                { DicomTag.SOPClassUID, DicomUID.SecondaryCaptureImageStorage.UID }
+            };
+            return new DicomFile(dataset);
+        }
+    }
+}

--- a/src/InformaticsGateway/Test/packages.lock.json
+++ b/src/InformaticsGateway/Test/packages.lock.json
@@ -1897,132 +1897,138 @@
       "monai.deploy.informaticsgateway": {
         "type": "Project",
         "dependencies": {
-          "Ardalis.GuardClauses": "4.0.1",
-          "DotNext.Threading": "4.7.4",
-          "HL7-dotnetcore": "2.35.0",
-          "Karambolo.Extensions.Logging.File": "3.4.0",
-          "Microsoft.EntityFrameworkCore": "6.0.15",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "6.0.15",
-          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "6.0.15",
-          "Microsoft.Extensions.Hosting": "6.0.1",
-          "Microsoft.Extensions.Logging": "6.0.0",
-          "Microsoft.Extensions.Logging.Console": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.InformaticsGateway.Api": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Common": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Configuration": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Database": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Database.Api": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Database.EntityFramework": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.DicomWeb.Client": "1.0.0",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.22",
-          "Monai.Deploy.Security": "0.1.3",
-          "Monai.Deploy.Storage": "0.2.16",
-          "Monai.Deploy.Storage.MinIO": "0.2.16",
-          "NLog": "5.1.3",
-          "NLog.Web.AspNetCore": "5.2.3",
-          "Polly": "7.2.3",
-          "Swashbuckle.AspNetCore": "6.5.0",
-          "fo-dicom": "5.0.3",
-          "fo-dicom.NLog": "5.0.3"
+          "Ardalis.GuardClauses": "[4.0.1, )",
+          "DotNext.Threading": "[4.7.4, )",
+          "HL7-dotnetcore": "[2.35.0, )",
+          "Karambolo.Extensions.Logging.File": "[3.4.0, )",
+          "Microsoft.EntityFrameworkCore": "[6.0.15, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[6.0.0, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "[6.0.15, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[6.0.15, )",
+          "Microsoft.Extensions.Hosting": "[6.0.1, )",
+          "Microsoft.Extensions.Logging": "[6.0.0, )",
+          "Microsoft.Extensions.Logging.Console": "[6.0.0, )",
+          "Microsoft.Extensions.Options": "[6.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Api": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Common": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Configuration": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Database": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Database.Api": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Database.EntityFramework": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.DicomWeb.Client": "[1.0.0, )",
+          "Monai.Deploy.Messaging.RabbitMQ": "[0.1.22, )",
+          "Monai.Deploy.Security": "[0.1.3, )",
+          "Monai.Deploy.Storage": "[0.2.16, )",
+          "Monai.Deploy.Storage.MinIO": "[0.2.16, )",
+          "NLog": "[5.1.3, )",
+          "NLog.Web.AspNetCore": "[5.2.3, )",
+          "Polly": "[7.2.3, )",
+          "Swashbuckle.AspNetCore": "[6.5.0, )",
+          "fo-dicom": "[5.0.3, )",
+          "fo-dicom.NLog": "[5.0.3, )"
         }
       },
       "monai.deploy.informaticsgateway.api": {
         "type": "Project",
         "dependencies": {
-          "Macross.Json.Extensions": "3.0.0",
-          "Microsoft.EntityFrameworkCore.Abstractions": "6.0.15",
-          "Monai.Deploy.InformaticsGateway.Common": "1.0.0",
-          "Monai.Deploy.Messaging": "0.1.22",
-          "Monai.Deploy.Storage": "0.2.16"
+          "Macross.Json.Extensions": "[3.0.0, )",
+          "Microsoft.EntityFrameworkCore.Abstractions": "[6.0.15, )",
+          "Monai.Deploy.InformaticsGateway.Common": "[1.0.0, )",
+          "Monai.Deploy.Messaging": "[0.1.22, )",
+          "Monai.Deploy.Storage": "[0.2.16, )"
         }
       },
       "monai.deploy.informaticsgateway.client.common": {
         "type": "Project",
         "dependencies": {
-          "Ardalis.GuardClauses": "4.0.1",
-          "System.Text.Json": "6.0.7"
+          "Ardalis.GuardClauses": "[4.0.1, )",
+          "System.Text.Json": "[6.0.7, )"
         }
       },
       "monai.deploy.informaticsgateway.common": {
         "type": "Project",
         "dependencies": {
-          "Ardalis.GuardClauses": "4.0.1",
-          "System.IO.Abstractions": "17.2.3",
-          "System.Threading.Tasks.Dataflow": "6.0.0",
-          "fo-dicom": "5.0.3"
+          "Ardalis.GuardClauses": "[4.0.1, )",
+          "System.IO.Abstractions": "[17.2.3, )",
+          "System.Threading.Tasks.Dataflow": "[6.0.0, )",
+          "fo-dicom": "[5.0.3, )"
         }
       },
       "monai.deploy.informaticsgateway.configuration": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.3",
-          "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.InformaticsGateway.Api": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Common": "1.0.0",
-          "Monai.Deploy.Messaging": "0.1.22",
-          "Monai.Deploy.Storage": "0.2.16",
-          "System.IO.Abstractions": "17.2.3"
+          "Microsoft.Extensions.Logging.Abstractions": "[6.0.3, )",
+          "Microsoft.Extensions.Options": "[6.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Api": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Common": "[1.0.0, )",
+          "Monai.Deploy.Messaging": "[0.1.22, )",
+          "Monai.Deploy.Storage": "[0.2.16, )",
+          "System.IO.Abstractions": "[17.2.3, )"
         }
       },
       "monai.deploy.informaticsgateway.database": {
         "type": "Project",
         "dependencies": {
-          "AspNetCore.HealthChecks.MongoDb": "6.0.2",
-          "Microsoft.EntityFrameworkCore": "6.0.15",
-          "Microsoft.Extensions.Configuration": "6.0.1",
-          "Microsoft.Extensions.Configuration.FileExtensions": "6.0.0",
-          "Microsoft.Extensions.Configuration.Json": "6.0.0",
-          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "6.0.15",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "6.0.0",
-          "Monai.Deploy.InformaticsGateway.Api": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Configuration": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Database.Api": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Database.EntityFramework": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Database.MongoDB": "1.0.0"
+          "AspNetCore.HealthChecks.MongoDb": "[6.0.2, )",
+          "Microsoft.EntityFrameworkCore": "[6.0.15, )",
+          "Microsoft.Extensions.Configuration": "[6.0.1, )",
+          "Microsoft.Extensions.Configuration.FileExtensions": "[6.0.0, )",
+          "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[6.0.15, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[6.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Api": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Configuration": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Database.Api": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Database.EntityFramework": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Database.MongoDB": "[1.0.0, )"
         }
       },
       "monai.deploy.informaticsgateway.database.api": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "6.0.15",
-          "Monai.Deploy.InformaticsGateway.Api": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Configuration": "1.0.0",
-          "Polly": "7.2.3"
+          "Microsoft.EntityFrameworkCore": "[6.0.15, )",
+          "Monai.Deploy.InformaticsGateway.Api": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Configuration": "[1.0.0, )",
+          "Polly": "[7.2.3, )"
         }
       },
       "monai.deploy.informaticsgateway.database.entityframework": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "6.0.15",
-          "Microsoft.EntityFrameworkCore.Sqlite": "6.0.15",
-          "Microsoft.Extensions.Configuration": "6.0.1",
-          "Microsoft.Extensions.Configuration.FileExtensions": "6.0.0",
-          "Microsoft.Extensions.Configuration.Json": "6.0.0",
-          "Monai.Deploy.InformaticsGateway.Api": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Configuration": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Database.Api": "1.0.0"
+          "Microsoft.EntityFrameworkCore": "[6.0.15, )",
+          "Microsoft.EntityFrameworkCore.Sqlite": "[6.0.15, )",
+          "Microsoft.Extensions.Configuration": "[6.0.1, )",
+          "Microsoft.Extensions.Configuration.FileExtensions": "[6.0.0, )",
+          "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Api": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Configuration": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Database.Api": "[1.0.0, )"
         }
       },
       "monai.deploy.informaticsgateway.database.mongodb": {
         "type": "Project",
         "dependencies": {
-          "Monai.Deploy.InformaticsGateway.Database.Api": "1.0.0",
-          "MongoDB.Driver": "2.19.1",
-          "MongoDB.Driver.Core": "2.19.1"
+          "Monai.Deploy.InformaticsGateway.Database.Api": "[1.0.0, )",
+          "MongoDB.Driver": "[2.19.1, )",
+          "MongoDB.Driver.Core": "[2.19.1, )"
         }
       },
       "monai.deploy.informaticsgateway.dicomweb.client": {
         "type": "Project",
         "dependencies": {
-          "Ardalis.GuardClauses": "4.0.1",
-          "Microsoft.AspNet.WebApi.Client": "5.2.9",
-          "Microsoft.Extensions.Http": "6.0.0",
-          "Microsoft.Net.Http.Headers": "2.2.8",
-          "Monai.Deploy.InformaticsGateway.Client.Common": "1.0.0",
-          "System.Linq.Async": "6.0.1",
-          "fo-dicom": "5.0.3"
+          "Ardalis.GuardClauses": "[4.0.1, )",
+          "Microsoft.AspNet.WebApi.Client": "[5.2.9, )",
+          "Microsoft.Extensions.Http": "[6.0.0, )",
+          "Microsoft.Net.Http.Headers": "[2.2.8, )",
+          "Monai.Deploy.InformaticsGateway.Client.Common": "[1.0.0, )",
+          "System.Linq.Async": "[6.0.1, )",
+          "fo-dicom": "[5.0.3, )"
+        }
+      },
+      "monai.deploy.informaticsgateway.test.plugins": {
+        "type": "Project",
+        "dependencies": {
+          "Monai.Deploy.InformaticsGateway.Api": "[1.0.0, )"
         }
       }
     }

--- a/src/Monai.Deploy.InformaticsGateway.sln
+++ b/src/Monai.Deploy.InformaticsGateway.sln
@@ -54,7 +54,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monai.Deploy.InformaticsGat
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monai.Deploy.InformaticsGateway.Database.MongoDB", "Database\MongoDB\Monai.Deploy.InformaticsGateway.Database.MongoDB.csproj", "{5ED73EEA-4DFA-426D-82E8-AA24D3CB4C31}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Monai.Deploy.InformaticsGateway.Database.MongoDB.Integration.Test", "Database\MongoDB\Integration.Test\Monai.Deploy.InformaticsGateway.Database.MongoDB.Integration.Test.csproj", "{2F849556-44B6-484A-B612-CB0FA5D29AC6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monai.Deploy.InformaticsGateway.Database.MongoDB.Integration.Test", "Database\MongoDB\Integration.Test\Monai.Deploy.InformaticsGateway.Database.MongoDB.Integration.Test.csproj", "{2F849556-44B6-484A-B612-CB0FA5D29AC6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monai.Deploy.InformaticsGateway.Test.Plugins", "InformaticsGateway\Test\Plugins\Monai.Deploy.InformaticsGateway.Test.Plugins.csproj", "{7E735CE9-CE74-450E-A4E8-060D185DDEF1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -366,6 +368,18 @@ Global
 		{2F849556-44B6-484A-B612-CB0FA5D29AC6}.Release|x64.Build.0 = Release|Any CPU
 		{2F849556-44B6-484A-B612-CB0FA5D29AC6}.Release|x86.ActiveCfg = Release|Any CPU
 		{2F849556-44B6-484A-B612-CB0FA5D29AC6}.Release|x86.Build.0 = Release|Any CPU
+		{7E735CE9-CE74-450E-A4E8-060D185DDEF1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E735CE9-CE74-450E-A4E8-060D185DDEF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E735CE9-CE74-450E-A4E8-060D185DDEF1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7E735CE9-CE74-450E-A4E8-060D185DDEF1}.Debug|x64.Build.0 = Debug|Any CPU
+		{7E735CE9-CE74-450E-A4E8-060D185DDEF1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7E735CE9-CE74-450E-A4E8-060D185DDEF1}.Debug|x86.Build.0 = Debug|Any CPU
+		{7E735CE9-CE74-450E-A4E8-060D185DDEF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E735CE9-CE74-450E-A4E8-060D185DDEF1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E735CE9-CE74-450E-A4E8-060D185DDEF1}.Release|x64.ActiveCfg = Release|Any CPU
+		{7E735CE9-CE74-450E-A4E8-060D185DDEF1}.Release|x64.Build.0 = Release|Any CPU
+		{7E735CE9-CE74-450E-A4E8-060D185DDEF1}.Release|x86.ActiveCfg = Release|Any CPU
+		{7E735CE9-CE74-450E-A4E8-060D185DDEF1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -387,6 +401,7 @@ Global
 		{EA930DE2-33C4-447C-9E26-31387652D408} = {B8E99EF7-84EA-4D11-B722-9EE81B89CD86}
 		{5ED73EEA-4DFA-426D-82E8-AA24D3CB4C31} = {290E4C9B-841D-4E2C-91A0-5A69BAB122F3}
 		{2F849556-44B6-484A-B612-CB0FA5D29AC6} = {B8E99EF7-84EA-4D11-B722-9EE81B89CD86}
+		{7E735CE9-CE74-450E-A4E8-060D185DDEF1} = {B8E99EF7-84EA-4D11-B722-9EE81B89CD86}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E23DC856-D033-49F6-9BC6-9F1D0ECD05CB}

--- a/tests/Integration.Test/Drivers/RabbitMqConsumer.cs
+++ b/tests/Integration.Test/Drivers/RabbitMqConsumer.cs
@@ -48,12 +48,13 @@ namespace Monai.Deploy.InformaticsGateway.Integration.Test.Drivers
             subscriberService.SubscribeAsync(
                 queueName,
                 queueName,
-                async (eventArgs) =>
+                (eventArgs) =>
                 {
                     _outputHelper.WriteLine($"Message received from queue {queueName} for {queueName}.");
                     _messages.Add(eventArgs.Message);
                     subscriberService.Acknowledge(eventArgs.Message);
                     _outputHelper.WriteLine($"{DateTime.UtcNow} - {queueName} message received with correlation ID={eventArgs.Message.CorrelationId}, delivery tag={eventArgs.Message.DeliveryTag}");
+                    return Task.CompletedTask;
                 });
         }
 

--- a/tests/Integration.Test/Features/DicomDimseScp.feature
+++ b/tests/Integration.Test/Features/DicomDimseScp.feature
@@ -44,7 +44,7 @@ Feature: DICOM DIMSE SCP Services
         When a C-STORE-RQ is sent to 'Informatics Gateway' with AET '<aet>' from 'TEST-RUNNER'
         Then a successful response should be received
         And <count> workflow requests sent to message broker
-        And studies are uploaded to storage service
+        And studies are uploaded to storage service with data input plugins
 
         Examples:
             | modality | count | aet             | timeout |

--- a/tests/Integration.Test/Monai.Deploy.InformaticsGateway.Integration.Test.csproj
+++ b/tests/Integration.Test/Monai.Deploy.InformaticsGateway.Integration.Test.csproj
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2022 MONAI Consortium
+  ~ Copyright 2022-2023 MONAI Consortium
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@
     <ProjectReference Include="..\..\src\Database\Monai.Deploy.InformaticsGateway.Database.csproj" />
     <ProjectReference Include="..\..\src\DicomWebClient\Monai.Deploy.InformaticsGateway.DicomWeb.Client.csproj" />
     <ProjectReference Include="..\..\src\InformaticsGateway\Monai.Deploy.InformaticsGateway.csproj" />
+    <ProjectReference Include="..\..\src\InformaticsGateway\Test\Plugins\Monai.Deploy.InformaticsGateway.Test.Plugins.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -89,7 +90,7 @@
 
   <Target Name="CopyPluginsBuild" AfterTargets="Build">
     <ItemGroup>
-      <PluginDlls Include="$(OutDir)Monai.Deploy.Messaging.RabbitMQ.dll;$(OutDir)Monai.Deploy.Storage.MinIO.dll;$(OutDir)Minio.dll" />
+      <PluginDlls Include="$(OutDir)Monai.Deploy.Messaging.RabbitMQ.dll;$(OutDir)Monai.Deploy.Storage.MinIO.dll;$(OutDir)Minio.dll;$(OutDir)Monai.Deploy.InformaticsGateway.Test.Plugins.dll" />
     </ItemGroup>
     <Copy SourceFiles="@(PluginDlls)" DestinationFolder="$(OutDir)\plug-ins\" SkipUnchangedFiles="true" />
     <Message Text="Files copied successfully to $(OutDir)\plug-ins\." Importance="high" />

--- a/tests/Integration.Test/StepDefinitions/DicomDimseScpServicesStepDefinitions.cs
+++ b/tests/Integration.Test/StepDefinitions/DicomDimseScpServicesStepDefinitions.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 MONAI Consortium
+ * Copyright 2022-2023 MONAI Consortium
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,8 +108,10 @@ namespace Monai.Deploy.InformaticsGateway.Integration.Test.StepDefinitions
                     Name = calledAeTitle,
                     Grouping = grouping,
                     Timeout = groupingTimeout,
-                    Workflows = new List<string>(DummyWorkflows)
+                    Workflows = new List<string>(DummyWorkflows),
+                    PluginAssemblies = new List<string>() { typeof(Monai.Deploy.InformaticsGateway.Test.Plugins.TestInputDataPluginModifyDicomFile).AssemblyQualifiedName }
                 }, CancellationToken.None);
+
                 _dataProvider.Workflows = DummyWorkflows;
             }
             catch (ProblemException ex)

--- a/tests/Integration.Test/StepDefinitions/SharedDefinitions.cs
+++ b/tests/Integration.Test/StepDefinitions/SharedDefinitions.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 MONAI Consortium
+ * Copyright 2022-2023 MONAI Consortium
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ using BoDi;
 using Monai.Deploy.InformaticsGateway.Configuration;
 using Monai.Deploy.InformaticsGateway.Integration.Test.Common;
 using Monai.Deploy.InformaticsGateway.Integration.Test.Drivers;
+using Monai.Deploy.InformaticsGateway.Test.Plugins;
 
 namespace Monai.Deploy.InformaticsGateway.Integration.Test.StepDefinitions
 {
@@ -69,6 +70,19 @@ namespace Monai.Deploy.InformaticsGateway.Integration.Test.StepDefinitions
         public async Task ThenXXFilesUploadedToStorageService()
         {
             await _assertions.ShouldHaveUploadedDicomDataToMinio(_receivedMessages.Messages, _dataProvider.DicomSpecs.FileHashes);
+        }
+
+        [Then(@"studies are uploaded to storage service with data input plugins")]
+        public async Task ThenXXFilesUploadedToStorageServiceWithDataInputPlugins()
+        {
+            await _assertions.ShouldHaveUploadedDicomDataToMinio(
+                _receivedMessages.Messages,
+                _dataProvider.DicomSpecs.FileHashes,
+                (dicomFile) =>
+                {
+                    dicomFile.Dataset.GetString(TestInputDataPluginModifyDicomFile.ExpectedTag)
+                        .Should().Be(TestInputDataPluginModifyDicomFile.ExpectedValue);
+                });
         }
     }
 }

--- a/tests/Integration.Test/packages.lock.json
+++ b/tests/Integration.Test/packages.lock.json
@@ -1792,141 +1792,147 @@
       "monai.deploy.informaticsgateway": {
         "type": "Project",
         "dependencies": {
-          "Ardalis.GuardClauses": "4.0.1",
-          "DotNext.Threading": "4.7.4",
-          "HL7-dotnetcore": "2.35.0",
-          "Karambolo.Extensions.Logging.File": "3.4.0",
-          "Microsoft.EntityFrameworkCore": "6.0.15",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "6.0.15",
-          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "6.0.15",
-          "Microsoft.Extensions.Hosting": "6.0.1",
-          "Microsoft.Extensions.Logging": "6.0.0",
-          "Microsoft.Extensions.Logging.Console": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.InformaticsGateway.Api": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Common": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Configuration": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Database": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Database.Api": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Database.EntityFramework": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.DicomWeb.Client": "1.0.0",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.22",
-          "Monai.Deploy.Security": "0.1.3",
-          "Monai.Deploy.Storage": "0.2.16",
-          "Monai.Deploy.Storage.MinIO": "0.2.16",
-          "NLog": "5.1.3",
-          "NLog.Web.AspNetCore": "5.2.3",
-          "Polly": "7.2.3",
-          "Swashbuckle.AspNetCore": "6.5.0",
-          "fo-dicom": "5.0.3",
-          "fo-dicom.NLog": "5.0.3"
+          "Ardalis.GuardClauses": "[4.0.1, )",
+          "DotNext.Threading": "[4.7.4, )",
+          "HL7-dotnetcore": "[2.35.0, )",
+          "Karambolo.Extensions.Logging.File": "[3.4.0, )",
+          "Microsoft.EntityFrameworkCore": "[6.0.15, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[6.0.0, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "[6.0.15, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[6.0.15, )",
+          "Microsoft.Extensions.Hosting": "[6.0.1, )",
+          "Microsoft.Extensions.Logging": "[6.0.0, )",
+          "Microsoft.Extensions.Logging.Console": "[6.0.0, )",
+          "Microsoft.Extensions.Options": "[6.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Api": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Common": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Configuration": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Database": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Database.Api": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Database.EntityFramework": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.DicomWeb.Client": "[1.0.0, )",
+          "Monai.Deploy.Messaging.RabbitMQ": "[0.1.22, )",
+          "Monai.Deploy.Security": "[0.1.3, )",
+          "Monai.Deploy.Storage": "[0.2.16, )",
+          "Monai.Deploy.Storage.MinIO": "[0.2.16, )",
+          "NLog": "[5.1.3, )",
+          "NLog.Web.AspNetCore": "[5.2.3, )",
+          "Polly": "[7.2.3, )",
+          "Swashbuckle.AspNetCore": "[6.5.0, )",
+          "fo-dicom": "[5.0.3, )",
+          "fo-dicom.NLog": "[5.0.3, )"
         }
       },
       "monai.deploy.informaticsgateway.api": {
         "type": "Project",
         "dependencies": {
-          "Macross.Json.Extensions": "3.0.0",
-          "Microsoft.EntityFrameworkCore.Abstractions": "6.0.15",
-          "Monai.Deploy.InformaticsGateway.Common": "1.0.0",
-          "Monai.Deploy.Messaging": "0.1.22",
-          "Monai.Deploy.Storage": "0.2.16"
+          "Macross.Json.Extensions": "[3.0.0, )",
+          "Microsoft.EntityFrameworkCore.Abstractions": "[6.0.15, )",
+          "Monai.Deploy.InformaticsGateway.Common": "[1.0.0, )",
+          "Monai.Deploy.Messaging": "[0.1.22, )",
+          "Monai.Deploy.Storage": "[0.2.16, )"
         }
       },
       "monai.deploy.informaticsgateway.client": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.AspNet.WebApi.Client": "5.2.9",
-          "Microsoft.Extensions.Http": "6.0.0",
-          "Monai.Deploy.InformaticsGateway.Api": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Client.Common": "1.0.0"
+          "Microsoft.AspNet.WebApi.Client": "[5.2.9, )",
+          "Microsoft.Extensions.Http": "[6.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Api": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Client.Common": "[1.0.0, )"
         }
       },
       "monai.deploy.informaticsgateway.client.common": {
         "type": "Project",
         "dependencies": {
-          "Ardalis.GuardClauses": "4.0.1",
-          "System.Text.Json": "6.0.7"
+          "Ardalis.GuardClauses": "[4.0.1, )",
+          "System.Text.Json": "[6.0.7, )"
         }
       },
       "monai.deploy.informaticsgateway.common": {
         "type": "Project",
         "dependencies": {
-          "Ardalis.GuardClauses": "4.0.1",
-          "System.IO.Abstractions": "17.2.3",
-          "System.Threading.Tasks.Dataflow": "6.0.0",
-          "fo-dicom": "5.0.3"
+          "Ardalis.GuardClauses": "[4.0.1, )",
+          "System.IO.Abstractions": "[17.2.3, )",
+          "System.Threading.Tasks.Dataflow": "[6.0.0, )",
+          "fo-dicom": "[5.0.3, )"
         }
       },
       "monai.deploy.informaticsgateway.configuration": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.3",
-          "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.InformaticsGateway.Api": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Common": "1.0.0",
-          "Monai.Deploy.Messaging": "0.1.22",
-          "Monai.Deploy.Storage": "0.2.16",
-          "System.IO.Abstractions": "17.2.3"
+          "Microsoft.Extensions.Logging.Abstractions": "[6.0.3, )",
+          "Microsoft.Extensions.Options": "[6.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Api": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Common": "[1.0.0, )",
+          "Monai.Deploy.Messaging": "[0.1.22, )",
+          "Monai.Deploy.Storage": "[0.2.16, )",
+          "System.IO.Abstractions": "[17.2.3, )"
         }
       },
       "monai.deploy.informaticsgateway.database": {
         "type": "Project",
         "dependencies": {
-          "AspNetCore.HealthChecks.MongoDb": "6.0.2",
-          "Microsoft.EntityFrameworkCore": "6.0.15",
-          "Microsoft.Extensions.Configuration": "6.0.1",
-          "Microsoft.Extensions.Configuration.FileExtensions": "6.0.0",
-          "Microsoft.Extensions.Configuration.Json": "6.0.0",
-          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "6.0.15",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "6.0.0",
-          "Monai.Deploy.InformaticsGateway.Api": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Configuration": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Database.Api": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Database.EntityFramework": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Database.MongoDB": "1.0.0"
+          "AspNetCore.HealthChecks.MongoDb": "[6.0.2, )",
+          "Microsoft.EntityFrameworkCore": "[6.0.15, )",
+          "Microsoft.Extensions.Configuration": "[6.0.1, )",
+          "Microsoft.Extensions.Configuration.FileExtensions": "[6.0.0, )",
+          "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[6.0.15, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[6.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Api": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Configuration": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Database.Api": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Database.EntityFramework": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Database.MongoDB": "[1.0.0, )"
         }
       },
       "monai.deploy.informaticsgateway.database.api": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "6.0.15",
-          "Monai.Deploy.InformaticsGateway.Api": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Configuration": "1.0.0",
-          "Polly": "7.2.3"
+          "Microsoft.EntityFrameworkCore": "[6.0.15, )",
+          "Monai.Deploy.InformaticsGateway.Api": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Configuration": "[1.0.0, )",
+          "Polly": "[7.2.3, )"
         }
       },
       "monai.deploy.informaticsgateway.database.entityframework": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "6.0.15",
-          "Microsoft.EntityFrameworkCore.Sqlite": "6.0.15",
-          "Microsoft.Extensions.Configuration": "6.0.1",
-          "Microsoft.Extensions.Configuration.FileExtensions": "6.0.0",
-          "Microsoft.Extensions.Configuration.Json": "6.0.0",
-          "Monai.Deploy.InformaticsGateway.Api": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Configuration": "1.0.0",
-          "Monai.Deploy.InformaticsGateway.Database.Api": "1.0.0"
+          "Microsoft.EntityFrameworkCore": "[6.0.15, )",
+          "Microsoft.EntityFrameworkCore.Sqlite": "[6.0.15, )",
+          "Microsoft.Extensions.Configuration": "[6.0.1, )",
+          "Microsoft.Extensions.Configuration.FileExtensions": "[6.0.0, )",
+          "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Api": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Configuration": "[1.0.0, )",
+          "Monai.Deploy.InformaticsGateway.Database.Api": "[1.0.0, )"
         }
       },
       "monai.deploy.informaticsgateway.database.mongodb": {
         "type": "Project",
         "dependencies": {
-          "Monai.Deploy.InformaticsGateway.Database.Api": "1.0.0",
-          "MongoDB.Driver": "2.19.1",
-          "MongoDB.Driver.Core": "2.19.1"
+          "Monai.Deploy.InformaticsGateway.Database.Api": "[1.0.0, )",
+          "MongoDB.Driver": "[2.19.1, )",
+          "MongoDB.Driver.Core": "[2.19.1, )"
         }
       },
       "monai.deploy.informaticsgateway.dicomweb.client": {
         "type": "Project",
         "dependencies": {
-          "Ardalis.GuardClauses": "4.0.1",
-          "Microsoft.AspNet.WebApi.Client": "5.2.9",
-          "Microsoft.Extensions.Http": "6.0.0",
-          "Microsoft.Net.Http.Headers": "2.2.8",
-          "Monai.Deploy.InformaticsGateway.Client.Common": "1.0.0",
-          "System.Linq.Async": "6.0.1",
-          "fo-dicom": "5.0.3"
+          "Ardalis.GuardClauses": "[4.0.1, )",
+          "Microsoft.AspNet.WebApi.Client": "[5.2.9, )",
+          "Microsoft.Extensions.Http": "[6.0.0, )",
+          "Microsoft.Net.Http.Headers": "[2.2.8, )",
+          "Monai.Deploy.InformaticsGateway.Client.Common": "[1.0.0, )",
+          "System.Linq.Async": "[6.0.1, )",
+          "fo-dicom": "[5.0.3, )"
+        }
+      },
+      "monai.deploy.informaticsgateway.test.plugins": {
+        "type": "Project",
+        "dependencies": {
+          "Monai.Deploy.InformaticsGateway.Api": "[1.0.0, )"
         }
       }
     }


### PR DESCRIPTION
### Description

Fixes #418.

- SCP service is now enabled with the new `IInputDataPluginEngine` interface using the default implementation `InputDataPluginEngine`. With every listening AE Title (AET), zero or more plug-ins can be configured through the `PluginAssemblies` property.  This allows an instance of  `IInputDataPluginEngine`  to be attached to the `ApplicationEntityHandler`, initializing each plug-in. When data enters the SCP service for the specified AET, the handler then calls `InputDataPluginEngine::ExecutePlugins()` to process each received DICOM file through configured plug-ins.
- New interface `IInputDataPlugin` to allow users to create their own input data processing plug-ins.
- Add unit tests with 2 demo plug-ins that implement `IInputDataPlugin`: `TestInputDataPluginAddWorkflow` and `TestInputDataPluginModifyDicomFile`
- Update SCP feature in the integration test to use `TestInputDataPluginModifyDicomFile` and verify the modified DICOM file.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] All tests passed locally.
- [x] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [x] User guide updated.
- [ ] I have updated the changelog
