### PR TITLE
gh-435 Fix CLI to read log dir path from NLog config file

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,44 @@
 
 # Changelog
 
+## 0.4.0
+
+[GitHub Milestone 0.4.0](https://github.com/Project-MONAI/monai-deploy-informatics-gateway/milestone/5)
+
+- gh-435 Fix CLI to read log dir path from NLog config file.
+
+
+## 0.3.21
+
+[GitHub Milestone 0.3.21](https://github.com/Project-MONAI/monai-deploy-informatics-gateway/milestone/26)
+
+- Remove the need to double copy files to storage service.
+
+## 0.3.20
+
+[GitHub Milestone 0.3.20](https://github.com/Project-MONAI/monai-deploy-informatics-gateway/milestone/25)
+
+- gh-396 Spawn new thread for processing echo requests.
+
+## 0.3.19
+
+[GitHub Milestone 0.3.19](https://github.com/Project-MONAI/monai-deploy-informatics-gateway/milestone/24)
+
+- gh-392 Fix GET /config/aetitle URL.
+
+## 0.3.18
+
+[GitHub Milestone 0.3.18](https://github.com/Project-MONAI/monai-deploy-informatics-gateway/milestone/23)
+
+- gh-390 New API to retrieve registered source AETs.
+
+## 0.3.11
+
+[GitHub Milestone 0.3.17](https://github.com/Project-MONAI/monai-deploy-informatics-gateway/milestone/22)
+
+- gh-385 Resets ActionBlock if faulted or cancelled in Payload assembler pipeline.
+
+
 ## 0.3.16
 
 [GitHub Milestone 0.3.16](https://github.com/Project-MONAI/monai-deploy-informatics-gateway/milestone/21)

--- a/src/CLI/Logging/Log.cs
+++ b/src/CLI/Logging/Log.cs
@@ -133,8 +133,8 @@ namespace Monai.Deploy.InformaticsGateway.CLI
         [LoggerMessage(EventId = 30043, Level = LogLevel.Debug, Message = "Available manifest names {names}.")]
         public static partial void AvailableManifest(this ILogger logger, string names);
 
-        [LoggerMessage(EventId = 30044, Level = LogLevel.Information, Message = "Saving appsettings.json to {path}.")]
-        public static partial void SaveAppSettings(this ILogger logger, string path);
+        [LoggerMessage(EventId = 30044, Level = LogLevel.Information, Message = "Saving {resource} to {path}.")]
+        public static partial void SaveAppSettings(this ILogger logger, string resource, string path);
 
         [LoggerMessage(EventId = 30045, Level = LogLevel.Information, Message = "{path} updated successfully.")]
         public static partial void AppSettingUpdated(this ILogger logger, string path);

--- a/src/CLI/Monai.Deploy.InformaticsGateway.CLI.csproj
+++ b/src/CLI/Monai.Deploy.InformaticsGateway.CLI.csproj
@@ -51,6 +51,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="..\InformaticsGateway\appsettings.json" Link="Resources\appsettings.json" />
+    <EmbeddedResource Include="..\InformaticsGateway\nlog.config" Link="Resources\nlog.config" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CLI/Options/Common.cs
+++ b/src/CLI/Options/Common.cs
@@ -25,9 +25,12 @@ namespace Monai.Deploy.InformaticsGateway.CLI
         public static readonly string MigDirectory = Path.Combine(HomeDir, ".mig");
         public static readonly string ContainerApplicationRootPath = "/opt/monai/ig";
         public static readonly string MountedConfigFilePath = Path.Combine(ContainerApplicationRootPath, "appsettings.json");
+        public static readonly string MountedNLogConfigFilePath = Path.Combine(ContainerApplicationRootPath, "nlog.config");
         public static readonly string MountedDatabasePath = "/database";
         public static readonly string MountedPlugInsPath = Path.Combine(ContainerApplicationRootPath, "plug-ins");
         public static readonly string ConfigFilePath = Path.Combine(MigDirectory, "appsettings.json");
+        public static readonly string NLogConfigFilePath = Path.Combine(MigDirectory, "nlog.config");
         public static readonly string AppSettingsResourceName = $"{typeof(Program).Namespace}.Resources.appsettings.json";
+        public static readonly string NLogConfigResourceName = $"{typeof(Program).Namespace}.Resources.nlog.config";
     }
 }

--- a/src/CLI/Program.cs
+++ b/src/CLI/Program.cs
@@ -63,6 +63,8 @@ namespace Monai.Deploy.InformaticsGateway.CLI
                                     services.AddScoped<IFileSystem, FileSystem>();
                                     services.AddScoped<IConfirmationPrompt, ConfirmationPrompt>();
                                     services.AddScoped<IConsoleRegion, ConsoleRegion>();
+                                    services.AddScoped<IConfigurationOptionAccessor, ConfigurationOptionAccessor>();
+                                    services.AddScoped<INLogConfigurationOptionAccessor, NLogConfigurationOptionAccessor>();
                                     services.AddHttpClient<InformaticsGatewayClient>();
                                     services.AddSingleton<IInformaticsGatewayClient>(p => p.GetRequiredService<InformaticsGatewayClient>());
                                     services.AddSingleton<IConfigurationService, ConfigurationService>();

--- a/src/CLI/Properties/launchSettings.json
+++ b/src/CLI/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Monai.Deploy.InformaticsGateway.CLI": {
       "commandName": "Project",
-      "commandLineArgs": "aet add -a Test"
+      "commandLineArgs": "start"
     }
   }
 }

--- a/src/CLI/Services/ConfigurationOptionAccessor.cs
+++ b/src/CLI/Services/ConfigurationOptionAccessor.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 MONAI Consortium
+ * Copyright 2021-2023 MONAI Consortium
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ namespace Monai.Deploy.InformaticsGateway.CLI.Services
 
         public ConfigurationOptionAccessor(IFileSystem fileSystem)
         {
-            _fileSystem = fileSystem;
+            _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
         }
 
         public int DicomListeningPort
@@ -237,7 +237,7 @@ namespace Monai.Deploy.InformaticsGateway.CLI.Services
         {
             get
             {
-                return GetValueFromJsonPath<string>("InformaticsGateway.storage.temporary");
+                return GetValueFromJsonPath<string>("InformaticsGateway.storage.localTemporaryStoragePath");
             }
         }
 

--- a/src/CLI/Services/ConfigurationOptionAccessor.cs
+++ b/src/CLI/Services/ConfigurationOptionAccessor.cs
@@ -77,11 +77,6 @@ namespace Monai.Deploy.InformaticsGateway.CLI.Services
         Uri InformaticsGatewayServerUri { get; }
 
         /// <summary>
-        /// Gets the log storage path from appsettings.json.
-        /// </summary>
-        string LogStoragePath { get; }
-
-        /// <summary>
         /// Gets or set the type of container runner from appsettings.json.
         /// </summary>
         Runner Runner { get; set; }
@@ -220,19 +215,6 @@ namespace Monai.Deploy.InformaticsGateway.CLI.Services
             get
             {
                 return new Uri(InformaticsGatewayServerEndpoint);
-            }
-        }
-
-        public string LogStoragePath
-        {
-            get
-            {
-                var logPath = GetValueFromJsonPath<string>("Logging.File.BasePath");
-                if (logPath.StartsWith("/"))
-                {
-                    return logPath;
-                }
-                return _fileSystem.Path.Combine(Common.ContainerApplicationRootPath, logPath);
             }
         }
 

--- a/src/CLI/Services/ConfigurationService.cs
+++ b/src/CLI/Services/ConfigurationService.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 MONAI Consortium
+ * Copyright 2021-2023 MONAI Consortium
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ using System.IO.Abstractions;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Ardalis.GuardClauses;
 using Microsoft.Extensions.Logging;
 
 namespace Monai.Deploy.InformaticsGateway.CLI.Services
@@ -35,6 +36,7 @@ namespace Monai.Deploy.InformaticsGateway.CLI.Services
         public bool IsConfigExists => _fileSystem.File.Exists(Common.ConfigFilePath);
 
         public IConfigurationOptionAccessor Configurations { get; }
+        public INLogConfigurationOptionAccessor NLogConfigurations { get; }
 
         public ConfigurationService(ILogger<ConfigurationService> logger, IFileSystem fileSystem, IEmbeddedResource embeddedResource)
         {
@@ -42,6 +44,7 @@ namespace Monai.Deploy.InformaticsGateway.CLI.Services
             _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
             _embeddedResource = embeddedResource ?? throw new ArgumentNullException(nameof(embeddedResource));
             Configurations = new ConfigurationOptionAccessor(fileSystem);
+            NLogConfigurations = new NLogConfigurationOptionAccessor();
         }
 
         public void CreateConfigDirectoryIfNotExist()
@@ -55,22 +58,32 @@ namespace Monai.Deploy.InformaticsGateway.CLI.Services
         public async Task Initialize(CancellationToken cancellationToken)
         {
             _logger.DebugMessage("Reading default application configurations...");
-            using var stream = _embeddedResource.GetManifestResourceStream(Common.AppSettingsResourceName);
+            await WriteConfigFile(Common.AppSettingsResourceName, Common.ConfigFilePath, cancellationToken).ConfigureAwait(false);
+            await WriteConfigFile(Common.NLogConfigResourceName, Common.NLogConfigFilePath, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task WriteConfigFile(string resourceName, string outputPath, CancellationToken cancellationToken)
+        {
+            Guard.Against.NullOrWhiteSpace(resourceName, nameof(resourceName));
+            Guard.Against.NullOrWhiteSpace(outputPath, nameof(outputPath));
+
+            using var stream = _embeddedResource.GetManifestResourceStream(resourceName);
 
             if (stream is null)
             {
                 _logger.AvailableManifest(string.Join(",", Assembly.GetExecutingAssembly().GetManifestResourceNames()));
-                throw new ConfigurationException($"Default configuration file could not be loaded, please reinstall the CLI.");
+                throw new ConfigurationException($"Default configuration file: {resourceName} could not be loaded, please reinstall the CLI.");
             }
             CreateConfigDirectoryIfNotExist();
 
-            _logger.SaveAppSettings(Common.ConfigFilePath);
-            using (var fileStream = _fileSystem.FileStream.Create(Common.ConfigFilePath, FileMode.Create))
+            _logger.SaveAppSettings(resourceName, outputPath);
+            using (var fileStream = _fileSystem.FileStream.Create(outputPath, FileMode.Create))
             {
                 await stream.CopyToAsync(fileStream, cancellationToken).ConfigureAwait(false);
                 await fileStream.FlushAsync(cancellationToken).ConfigureAwait(false);
             }
-            _logger.AppSettingUpdated(Common.ConfigFilePath);
+            _logger.AppSettingUpdated(outputPath);
+
         }
     }
 }

--- a/src/CLI/Services/ConfigurationService.cs
+++ b/src/CLI/Services/ConfigurationService.cs
@@ -38,13 +38,18 @@ namespace Monai.Deploy.InformaticsGateway.CLI.Services
         public IConfigurationOptionAccessor Configurations { get; }
         public INLogConfigurationOptionAccessor NLogConfigurations { get; }
 
-        public ConfigurationService(ILogger<ConfigurationService> logger, IFileSystem fileSystem, IEmbeddedResource embeddedResource)
+        public ConfigurationService(
+            ILogger<ConfigurationService> logger,
+            IFileSystem fileSystem,
+            IEmbeddedResource embeddedResource,
+            IConfigurationOptionAccessor configurationOptionAccessor,
+            INLogConfigurationOptionAccessor nLogConfigurationOptionAccessor)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
             _embeddedResource = embeddedResource ?? throw new ArgumentNullException(nameof(embeddedResource));
-            Configurations = new ConfigurationOptionAccessor(fileSystem);
-            NLogConfigurations = new NLogConfigurationOptionAccessor();
+            Configurations = configurationOptionAccessor ?? throw new ArgumentNullException(nameof(configurationOptionAccessor));
+            NLogConfigurations = nLogConfigurationOptionAccessor ?? throw new ArgumentNullException(nameof(nLogConfigurationOptionAccessor));
         }
 
         public void CreateConfigDirectoryIfNotExist()

--- a/src/CLI/Services/DockerRunner.cs
+++ b/src/CLI/Services/DockerRunner.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 MONAI Consortium
+ * Copyright 2021-2023 MONAI Consortium
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,6 +114,7 @@ namespace Monai.Deploy.InformaticsGateway.CLI.Services
             };
 
             createContainerParams.HostConfig.PortBindings = new Dictionary<string, IList<PortBinding>>();
+            createContainerParams.HostConfig.NetworkMode = "monaideploy";
 
             _logger.DockerPrtBinding(_configurationService.Configurations.DicomListeningPort);
             createContainerParams.ExposedPorts.Add($"{_configurationService.Configurations.DicomListeningPort}/tcp", new EmptyStruct());
@@ -135,9 +136,9 @@ namespace Monai.Deploy.InformaticsGateway.CLI.Services
             _fileSystem.Directory.CreateDirectoryIfNotExists(_configurationService.Configurations.HostDatabaseStorageMount);
             createContainerParams.HostConfig.Mounts.Add(new Mount { Type = "bind", ReadOnly = false, Source = _configurationService.Configurations.HostDatabaseStorageMount, Target = Common.MountedDatabasePath });
 
-            _logger.DockerMountAppLogs(_configurationService.Configurations.HostLogsStorageMount, _configurationService.Configurations.LogStoragePath);
+            _logger.DockerMountAppLogs(_configurationService.Configurations.HostLogsStorageMount, _configurationService.NLogConfigurations.LogStoragePath);
             _fileSystem.Directory.CreateDirectoryIfNotExists(_configurationService.Configurations.HostLogsStorageMount);
-            createContainerParams.HostConfig.Mounts.Add(new Mount { Type = "bind", ReadOnly = false, Source = _configurationService.Configurations.HostLogsStorageMount, Target = _configurationService.Configurations.LogStoragePath });
+            createContainerParams.HostConfig.Mounts.Add(new Mount { Type = "bind", ReadOnly = false, Source = _configurationService.Configurations.HostLogsStorageMount, Target = _configurationService.NLogConfigurations.LogStoragePath });
 
             _logger.DockerMountPlugins(_configurationService.Configurations.HostPlugInsStorageMount, Common.MountedPlugInsPath);
             _fileSystem.Directory.CreateDirectoryIfNotExists(_configurationService.Configurations.HostPlugInsStorageMount);

--- a/src/CLI/Services/EmbeddedResource.cs
+++ b/src/CLI/Services/EmbeddedResource.cs
@@ -29,7 +29,8 @@ namespace Monai.Deploy.InformaticsGateway.CLI.Services
         public Stream GetManifestResourceStream(string name)
         {
             Guard.Against.NullOrWhiteSpace(name, nameof(name));
-            return GetType().Assembly.GetManifestResourceStream(Common.AppSettingsResourceName);
+
+            return GetType().Assembly.GetManifestResourceStream(name);
         }
     }
 }

--- a/src/CLI/Services/IConfigurationService.cs
+++ b/src/CLI/Services/IConfigurationService.cs
@@ -27,6 +27,11 @@ namespace Monai.Deploy.InformaticsGateway.CLI.Services
         IConfigurationOptionAccessor Configurations { get; }
 
         /// <summary>
+        /// Gets the configurations inside nlog.config
+        /// </summary>
+        INLogConfigurationOptionAccessor NLogConfigurations { get; }
+
+        /// <summary>
         /// Gets whether the configuration file exists or not.
         /// </summary>
         bool IsConfigExists { get; }

--- a/src/CLI/Services/NLogConfigurationOptionAccessor.cs
+++ b/src/CLI/Services/NLogConfigurationOptionAccessor.cs
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Xml;
+
+namespace Monai.Deploy.InformaticsGateway.CLI.Services
+{
+    public interface INLogConfigurationOptionAccessor
+    {
+        /// <summary>
+        /// Gets the logs directory path.
+        /// </summary>
+        string LogStoragePath { get; }
+    }
+
+    public class NLogConfigurationOptionAccessor : INLogConfigurationOptionAccessor
+    {
+        private readonly XmlDocument _xmlDocument;
+        private readonly XmlNamespaceManager _namespaceManager;
+
+        public NLogConfigurationOptionAccessor()
+        {
+            _xmlDocument = new XmlDocument();
+            _xmlDocument.Load(Common.NLogConfigFilePath);
+            _namespaceManager = new XmlNamespaceManager(_xmlDocument.NameTable);
+            _namespaceManager.AddNamespace("ns", "http://www.nlog-project.org/schemas/NLog.xsd");
+        }
+
+        public string LogStoragePath
+        {
+            get
+            {
+                var value = _xmlDocument.SelectSingleNode("//ns:variable[@name='logDir']/@value", _namespaceManager).InnerText;
+                value = value.Replace("${basedir}", Common.ContainerApplicationRootPath);
+                return value;
+            }
+        }
+    }
+}

--- a/src/CLI/Services/NLogConfigurationOptionAccessor.cs
+++ b/src/CLI/Services/NLogConfigurationOptionAccessor.cs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+using System;
+using System.IO.Abstractions;
 using System.Xml;
 
 namespace Monai.Deploy.InformaticsGateway.CLI.Services
@@ -31,10 +33,16 @@ namespace Monai.Deploy.InformaticsGateway.CLI.Services
         private readonly XmlDocument _xmlDocument;
         private readonly XmlNamespaceManager _namespaceManager;
 
-        public NLogConfigurationOptionAccessor()
+        public NLogConfigurationOptionAccessor(IFileSystem fileSystem)
         {
+            if (fileSystem is null)
+            {
+                throw new ArgumentNullException(nameof(fileSystem));
+            }
+
+            var xml = fileSystem.File.ReadAllText(Common.NLogConfigFilePath);
             _xmlDocument = new XmlDocument();
-            _xmlDocument.Load(Common.NLogConfigFilePath);
+            _xmlDocument.LoadXml(xml);
             _namespaceManager = new XmlNamespaceManager(_xmlDocument.NameTable);
             _namespaceManager.AddNamespace("ns", "http://www.nlog-project.org/schemas/NLog.xsd");
         }

--- a/src/CLI/Test/ConfigurationOptionAccessorTest.cs
+++ b/src/CLI/Test/ConfigurationOptionAccessorTest.cs
@@ -1,0 +1,194 @@
+﻿/*
+ * Copyright 2021-2023 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using Ardalis.GuardClauses;
+using Monai.Deploy.InformaticsGateway.CLI.Services;
+using Xunit;
+
+namespace Monai.Deploy.InformaticsGateway.CLI.Test
+{
+    public class ConfigurationOptionAccessorTest
+    {
+        private readonly IFileSystem _fileSystem;
+
+        public ConfigurationOptionAccessorTest()
+        {
+        }
+
+        [Fact(DisplayName = "ConfigurationOptionAccessor Constructor")]
+        public void DockerRunner_Constructor()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ConfigurationOptionAccessor(null));
+        }
+
+        [Fact]
+        public void DicomListeningPort_Get_ReturnsValue()
+        {
+            var fileSystem = SetupFileSystem("{\"InformaticsGateway\": {\"dicom\": {\"scp\": {\"port\": 104}}}}");
+            var configurationOptionAccessor = new ConfigurationOptionAccessor(fileSystem);
+
+            Assert.Equal(104, configurationOptionAccessor.DicomListeningPort);
+        }
+
+        [Fact]
+        public void DicomListeningPort_Set_UpdatesValue()
+        {
+            var fileSystem = SetupFileSystem("{\"InformaticsGateway\": {\"dicom\": {\"scp\": {\"port\": 104}}}}");
+            var configurationOptionAccessor = new ConfigurationOptionAccessor(fileSystem);
+            configurationOptionAccessor.DicomListeningPort = 1000;
+            Assert.Equal(1000, configurationOptionAccessor.DicomListeningPort);
+        }
+
+        [Fact]
+        public void Hl7ListeningPort_Get_ReturnsValue()
+        {
+            var fileSystem = SetupFileSystem("{\"InformaticsGateway\": {\"hl7\": {\"port\": 2575}}}");
+            var configurationOptionAccessor = new ConfigurationOptionAccessor(fileSystem);
+
+            Assert.Equal(2575, configurationOptionAccessor.Hl7ListeningPort);
+        }
+
+        [Fact]
+        public void Hl7ListeningPort_Set_UpdatesValue()
+        {
+            var fileSystem = SetupFileSystem("{\"InformaticsGateway\": {\"hl7\": {\"port\": 2575}}}");
+            var configurationOptionAccessor = new ConfigurationOptionAccessor(fileSystem);
+            configurationOptionAccessor.Hl7ListeningPort = 1000;
+            Assert.Equal(1000, configurationOptionAccessor.Hl7ListeningPort);
+        }
+
+        [Fact]
+        public void DockerImagePrefix_Get_ReturnsValue()
+        {
+            var fileSystem = SetupFileSystem("{\"Cli\": {\"DockerImagePrefix\": \"ghcr.io/project-monai/monai-deploy-informatics-gateway\"}}");
+            var configurationOptionAccessor = new ConfigurationOptionAccessor(fileSystem);
+
+            Assert.Equal("ghcr.io/project-monai/monai-deploy-informatics-gateway", configurationOptionAccessor.DockerImagePrefix);
+        }
+
+        [Fact]
+        public void HostDatabaseStorageMount_Get_ReturnsValue()
+        {
+            var fileSystem = SetupFileSystem("{\"Cli\": {\"HostDatabaseStorageMount\": \"~/.mig/database\"}}");
+            var configurationOptionAccessor = new ConfigurationOptionAccessor(fileSystem);
+
+            Assert.Equal($"{Common.HomeDir}/.mig/database", configurationOptionAccessor.HostDatabaseStorageMount);
+        }
+
+        [Fact]
+        public void HostDataStorageMount_Get_ReturnsValue()
+        {
+            var fileSystem = SetupFileSystem("{\"Cli\": {\"HostDataStorageMount\": \"~/.mig/data\"}}");
+            var configurationOptionAccessor = new ConfigurationOptionAccessor(fileSystem);
+
+            Assert.Equal($"{Common.HomeDir}/.mig/data", configurationOptionAccessor.HostDataStorageMount);
+        }
+
+        [Fact]
+        public void HostPlugInsStorageMount_Get_ReturnsValue()
+        {
+            var fileSystem = SetupFileSystem("{\"Cli\": {\"HostPlugInsStorageMount\": \"~/.mig/plug-ins\"}}");
+            var configurationOptionAccessor = new ConfigurationOptionAccessor(fileSystem);
+
+            Assert.Equal($"{Common.HomeDir}/.mig/plug-ins", configurationOptionAccessor.HostPlugInsStorageMount);
+        }
+
+        [Fact]
+        public void HostLogsStorageMount_Get_ReturnsValue()
+        {
+            var fileSystem = SetupFileSystem("{\"Cli\": {\"HostLogsStorageMount\": \"~/.mig/logs\"}}");
+            var configurationOptionAccessor = new ConfigurationOptionAccessor(fileSystem);
+
+            Assert.Equal($"{Common.HomeDir}/.mig/logs", configurationOptionAccessor.HostLogsStorageMount);
+        }
+
+        [Fact]
+        public void InformaticsGatewayServerEndpoint_Get_ReturnsValue()
+        {
+            var fileSystem = SetupFileSystem("{\"Cli\": {\"InformaticsGatewayServerEndpoint\": \"http://localhost:5000\"}}");
+            var configurationOptionAccessor = new ConfigurationOptionAccessor(fileSystem);
+
+            Assert.Equal("http://localhost:5000", configurationOptionAccessor.InformaticsGatewayServerEndpoint);
+        }
+
+        [Fact]
+        public void InformaticsGatewayServerEndpoint_Set_UpdatesValue()
+        {
+            var fileSystem = SetupFileSystem("{\"Cli\": {\"InformaticsGatewayServerEndpoint\": \"http://localhost:5000\"}}");
+            var configurationOptionAccessor = new ConfigurationOptionAccessor(fileSystem);
+            configurationOptionAccessor.InformaticsGatewayServerEndpoint = "http://hello-world";
+            Assert.Equal("http://hello-world", configurationOptionAccessor.InformaticsGatewayServerEndpoint);
+        }
+
+        [Fact]
+        public void InformaticsGatewayServerPort_Get_ReturnsValue()
+        {
+            var fileSystem = SetupFileSystem("{\"Cli\": {\"InformaticsGatewayServerEndpoint\": \"http://localhost:5000\"}}");
+            var configurationOptionAccessor = new ConfigurationOptionAccessor(fileSystem);
+
+            Assert.Equal(5000, configurationOptionAccessor.InformaticsGatewayServerPort);
+        }
+
+        [Fact]
+        public void InformaticsGatewayServerUri_Get_ReturnsValue()
+        {
+            var fileSystem = SetupFileSystem("{\"Cli\": {\"InformaticsGatewayServerEndpoint\": \"http://localhost:5000\"}}");
+            var configurationOptionAccessor = new ConfigurationOptionAccessor(fileSystem);
+
+            Assert.Equal(new Uri("http://localhost:5000"), configurationOptionAccessor.InformaticsGatewayServerUri);
+        }
+
+        [Fact]
+        public void Runner_Get_ReturnsValue()
+        {
+            var fileSystem = SetupFileSystem("{\"Cli\": {\"Runner\": \"Docker\"}}");
+            var configurationOptionAccessor = new ConfigurationOptionAccessor(fileSystem);
+
+            Assert.Equal(Runner.Docker, configurationOptionAccessor.Runner);
+        }
+
+        [Fact]
+        public void Runner_Set_UpdatesValue()
+        {
+            var fileSystem = SetupFileSystem("{\"Cli\": {\"Runner\": \"Docker\"}}");
+            var configurationOptionAccessor = new ConfigurationOptionAccessor(fileSystem);
+            configurationOptionAccessor.Runner = Runner.Kubernetes;
+            Assert.Equal(Runner.Kubernetes, configurationOptionAccessor.Runner);
+        }
+
+        [Fact]
+        public void TempStoragePath_Get_ReturnsValue()
+        {
+            var fileSystem = SetupFileSystem("{\"InformaticsGateway\": {\"storage\": {\"localTemporaryStoragePath\": \"/payloads\"}}}");
+            var configurationOptionAccessor = new ConfigurationOptionAccessor(fileSystem);
+            Assert.Equal("/payloads", configurationOptionAccessor.TempStoragePath);
+        }
+
+        private IFileSystem SetupFileSystem(string config)
+        {
+            Guard.Against.NullOrWhiteSpace(config, nameof(config));
+
+            return new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {Common.ConfigFilePath, new MockFileData(config) }
+            });
+        }
+    }
+}

--- a/src/CLI/Test/ConfigurationServiceTest.cs
+++ b/src/CLI/Test/ConfigurationServiceTest.cs
@@ -33,29 +33,35 @@ namespace Monai.Deploy.InformaticsGateway.CLI.Test
         private readonly Mock<ILogger<ConfigurationService>> _logger;
         private readonly Mock<IFileSystem> _fileSystem;
         private readonly Mock<IEmbeddedResource> _embeddedResource;
+        private readonly Mock<IConfigurationOptionAccessor> _configurationOptionAccessor;
+        private readonly Mock<INLogConfigurationOptionAccessor> _nLogConfigurationOptionAccessor;
 
         public ConfigurationServiceTest()
         {
             _logger = new Mock<ILogger<ConfigurationService>>();
             _fileSystem = new Mock<IFileSystem>();
             _embeddedResource = new Mock<IEmbeddedResource>();
+            _configurationOptionAccessor = new Mock<IConfigurationOptionAccessor>();
+            _nLogConfigurationOptionAccessor = new Mock<INLogConfigurationOptionAccessor>();
         }
 
         [Fact(DisplayName = "ConfigurationServiceTest constructor")]
         public void ConfigurationServiceTest_Constructor()
         {
-            Assert.Throws<ArgumentNullException>(() => new ConfigurationService(null, null, null));
-            Assert.Throws<ArgumentNullException>(() => new ConfigurationService(_logger.Object, null, null));
-            Assert.Throws<ArgumentNullException>(() => new ConfigurationService(_logger.Object, _fileSystem.Object, null));
+            Assert.Throws<ArgumentNullException>(() => new ConfigurationService(null, null, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new ConfigurationService(_logger.Object, null, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new ConfigurationService(_logger.Object, _fileSystem.Object, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new ConfigurationService(_logger.Object, _fileSystem.Object, _embeddedResource.Object, null, null));
+            Assert.Throws<ArgumentNullException>(() => new ConfigurationService(_logger.Object, _fileSystem.Object, _embeddedResource.Object, _configurationOptionAccessor.Object, null));
 
-            var svc = new ConfigurationService(_logger.Object, _fileSystem.Object, _embeddedResource.Object);
+            var svc = new ConfigurationService(_logger.Object, _fileSystem.Object, _embeddedResource.Object, _configurationOptionAccessor.Object, _nLogConfigurationOptionAccessor.Object);
             Assert.NotNull(svc.Configurations);
         }
 
         [Fact(DisplayName = "CreateConfigDirectoryIfNotExist creates directory")]
         public void CreateConfigDirectoryIfNotExist_CreateDirectory()
         {
-            var svc = new ConfigurationService(_logger.Object, _fileSystem.Object, _embeddedResource.Object);
+            var svc = new ConfigurationService(_logger.Object, _fileSystem.Object, _embeddedResource.Object, _configurationOptionAccessor.Object, _nLogConfigurationOptionAccessor.Object);
 
             _fileSystem.Setup(p => p.Directory.Exists(It.IsAny<string>())).Returns(false);
             svc.CreateConfigDirectoryIfNotExist();
@@ -66,7 +72,7 @@ namespace Monai.Deploy.InformaticsGateway.CLI.Test
         [Fact(DisplayName = "CreateConfigDirectoryIfNotExist skips creating directory")]
         public void CreateConfigDirectoryIfNotExist_SkipsCreation()
         {
-            var svc = new ConfigurationService(_logger.Object, _fileSystem.Object, _embeddedResource.Object);
+            var svc = new ConfigurationService(_logger.Object, _fileSystem.Object, _embeddedResource.Object, _configurationOptionAccessor.Object, _nLogConfigurationOptionAccessor.Object);
 
             _fileSystem.Setup(p => p.Directory.Exists(It.IsAny<string>())).Returns(true);
             svc.CreateConfigDirectoryIfNotExist();
@@ -77,7 +83,7 @@ namespace Monai.Deploy.InformaticsGateway.CLI.Test
         [Fact(DisplayName = "IsInitialized")]
         public void IsInitialized()
         {
-            var svc = new ConfigurationService(_logger.Object, _fileSystem.Object, _embeddedResource.Object);
+            var svc = new ConfigurationService(_logger.Object, _fileSystem.Object, _embeddedResource.Object, _configurationOptionAccessor.Object, _nLogConfigurationOptionAccessor.Object);
 
             _fileSystem.Setup(p => p.Directory.Exists(It.IsAny<string>())).Returns(true);
             _fileSystem.Setup(p => p.File.Exists(It.IsAny<string>())).Returns(true);
@@ -89,7 +95,7 @@ namespace Monai.Deploy.InformaticsGateway.CLI.Test
         [Fact(DisplayName = "IsConfigExists")]
         public void ConfigurationExists()
         {
-            var svc = new ConfigurationService(_logger.Object, _fileSystem.Object, _embeddedResource.Object);
+            var svc = new ConfigurationService(_logger.Object, _fileSystem.Object, _embeddedResource.Object, _configurationOptionAccessor.Object, _nLogConfigurationOptionAccessor.Object);
 
             _fileSystem.Setup(p => p.File.Exists(It.IsAny<string>())).Returns(true);
             Assert.True(svc.IsConfigExists);
@@ -102,7 +108,7 @@ namespace Monai.Deploy.InformaticsGateway.CLI.Test
         {
             _embeddedResource.Setup(p => p.GetManifestResourceStream(It.IsAny<string>())).Returns(default(Stream));
 
-            var svc = new ConfigurationService(_logger.Object, _fileSystem.Object, _embeddedResource.Object);
+            var svc = new ConfigurationService(_logger.Object, _fileSystem.Object, _embeddedResource.Object, _configurationOptionAccessor.Object, _nLogConfigurationOptionAccessor.Object);
             await Assert.ThrowsAsync<ConfigurationException>(async () => await svc.Initialize(CancellationToken.None));
         }
 
@@ -118,7 +124,7 @@ namespace Monai.Deploy.InformaticsGateway.CLI.Test
             _embeddedResource.Setup(p => p.GetManifestResourceStream(It.Is<string>(p => p == Common.AppSettingsResourceName))).Returns(appConfigMemoryStream);
             _embeddedResource.Setup(p => p.GetManifestResourceStream(It.Is<string>(p => p == Common.NLogConfigResourceName))).Returns(nLogConfigMemoryStream);
 
-            var svc = new ConfigurationService(_logger.Object, fileSystem, _embeddedResource.Object);
+            var svc = new ConfigurationService(_logger.Object, fileSystem, _embeddedResource.Object, _configurationOptionAccessor.Object, _nLogConfigurationOptionAccessor.Object);
             await svc.Initialize(CancellationToken.None);
 
             _embeddedResource.Verify(p => p.GetManifestResourceStream(Common.AppSettingsResourceName), Times.Once());

--- a/src/CLI/Test/DockerRunnerTest.cs
+++ b/src/CLI/Test/DockerRunnerTest.cs
@@ -163,7 +163,7 @@ namespace Monai.Deploy.InformaticsGateway.CLI.Test
             _configurationService.SetupGet(p => p.Configurations.HostLogsStorageMount).Returns("/logs");
             _configurationService.SetupGet(p => p.Configurations.HostPlugInsStorageMount).Returns("/plug-ins");
             _configurationService.SetupGet(p => p.Configurations.TempStoragePath).Returns("/tempdata");
-            _configurationService.SetupGet(p => p.Configurations.LogStoragePath).Returns("/templogs");
+            _configurationService.SetupGet(p => p.NLogConfigurations.LogStoragePath).Returns("/templogs");
 
             Assert.True(await runner.StartApplication(image, CancellationToken.None));
             Assert.False(await runner.StartApplication(image, CancellationToken.None));

--- a/src/CLI/Test/NLogConfigurationOptionAccessorTest.cs
+++ b/src/CLI/Test/NLogConfigurationOptionAccessorTest.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * Copyright 2021-2023 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using Monai.Deploy.InformaticsGateway.CLI.Services;
+using Xunit;
+
+namespace Monai.Deploy.InformaticsGateway.CLI.Test
+{
+    public class NLogConfigurationOptionAccessorTest
+    {
+        private readonly IFileSystem _fileSystem;
+
+        public NLogConfigurationOptionAccessorTest()
+        {
+        }
+
+        [Fact(DisplayName = "NLogConfigurationOptionAccessor Constructor")]
+        public void DockerRunner_Constructor()
+        {
+            Assert.Throws<ArgumentNullException>(() => new NLogConfigurationOptionAccessor(null));
+        }
+
+
+        [Fact]
+        public void DicomListeningPort_Get_ReturnsValue()
+        {
+            var fileSystem = SetupFileSystem();
+            var configurationOptionAccessor = new NLogConfigurationOptionAccessor(fileSystem);
+
+            Assert.Equal($"{Common.ContainerApplicationRootPath}/logs/", configurationOptionAccessor.LogStoragePath);
+        }
+
+        private IFileSystem SetupFileSystem()
+        {
+            return new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {Common.NLogConfigFilePath, new MockFileData("<nlog xmlns=\"http://www.nlog-project.org/schemas/NLog.xsd\">\r\n  <variable name=\"logDir\" value=\"${basedir}/logs/\" />\r\n</nlog>") }
+            });
+        }
+    }
+}

--- a/src/CLI/Test/ProgramTest.cs
+++ b/src/CLI/Test/ProgramTest.cs
@@ -25,7 +25,7 @@ namespace Monai.Deploy.InformaticsGateway.CLI.Test
         public void Startup_RunsProperly()
         {
             var host = Program.BuildParser();
-
+            
             Assert.NotNull(host);
         }
     }


### PR DESCRIPTION
### Description

Fixes #435 to read application's log output directory path from NLog config file instead of `appsettings.json` since we've moved to NLog.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] I have updated the changelog
