### PR TITLE
attempt to fix export deadlocks

### DIFF
--- a/tests/Integration.Test/Features/RemoteAppExecutionPlugIn.feature
+++ b/tests/Integration.Test/Features/RemoteAppExecutionPlugIn.feature
@@ -25,3 +25,9 @@ re-identifying data sent and received by the MIG respectively.
         Given a study that is exported to the test host
         When the study is received and sent back to Informatics Gateway
         Then ensure the original study and the received study are the same
+
+   @messaging_workflow_request @messaging
+    Scenario: End-to-end test of plug-ins with one failing
+        Given a study that is exported to the test host with a bad plugin
+        When the study is received and sent back to Informatics Gateway
+        Then ensure the original study and the received study are the same


### PR DESCRIPTION
### Description

We've seen instances where an export message with an incorrect name can halt exports and cause issues.
 
this adds some try/catch to the TransformBlock's on an exception it now sets the file upload to failed so the process can continue.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] I have updated the changelog
