### PR TITLE
fix for where hl7Config plugin is blank

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-jammy as build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy as build
 
 # Install the tools
 RUN dotnet tool install --tool-path /tools dotnet-trace

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy as build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-jammy as build
 
 # Install the tools
 RUN dotnet tool install --tool-path /tools dotnet-trace
@@ -36,11 +36,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get clean \
  && apt-get update \
  && apt-get install -y --no-install-recommends curl \
- && apt-get install -y libc6-dev=2.35-0ubuntu3.6 \
+ && apt-get install -y libc6-dev=2.35-0ubuntu3.7 \
  && rm -rf /var/lib/apt/lists                           # this is a workaround for Mongo encryption library
-
-
-
 
 WORKDIR /opt/monai/ig
 

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -586,6 +586,7 @@
       - 8.0.1
       - 8.0.2
       - 8.0.3
+      - 8.0.5
     :when: 2022-10-14T23:37:16.793Z
     :who: mocsharp
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)

--- a/src/Api/packages.lock.json
+++ b/src/Api/packages.lock.json
@@ -41,9 +41,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.2, )",
-        "resolved": "8.0.2",
-        "contentHash": "hKTrehpfVzOhAz0mreaTAZgbz0DrMEbWq4n3hAo8Ks6WdxdqQhNPvzOqn9VygKuWf1bmxPdraqzTaXriO/sn0A=="
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "0kwNg0LBIvVTx9A2mo9Mnw4wLGtaeQgjSz5P13bOOwdWPPLe9HzI+XTkwiMhS7iQCM6X4LAbFR76xScaMw0MrA=="
       },
       "Monai.Deploy.Messaging": {
         "type": "Direct",

--- a/src/CLI/packages.lock.json
+++ b/src/CLI/packages.lock.json
@@ -35,9 +35,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.2, )",
-        "resolved": "8.0.2",
-        "contentHash": "hKTrehpfVzOhAz0mreaTAZgbz0DrMEbWq4n3hAo8Ks6WdxdqQhNPvzOqn9VygKuWf1bmxPdraqzTaXriO/sn0A=="
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "0kwNg0LBIvVTx9A2mo9Mnw4wLGtaeQgjSz5P13bOOwdWPPLe9HzI+XTkwiMhS7iQCM6X4LAbFR76xScaMw0MrA=="
       },
       "System.CommandLine.Hosting": {
         "type": "Direct",

--- a/src/Configuration/packages.lock.json
+++ b/src/Configuration/packages.lock.json
@@ -4,9 +4,9 @@
     "net8.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.2, )",
-        "resolved": "8.0.2",
-        "contentHash": "hKTrehpfVzOhAz0mreaTAZgbz0DrMEbWq4n3hAo8Ks6WdxdqQhNPvzOqn9VygKuWf1bmxPdraqzTaXriO/sn0A=="
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "0kwNg0LBIvVTx9A2mo9Mnw4wLGtaeQgjSz5P13bOOwdWPPLe9HzI+XTkwiMhS7iQCM6X4LAbFR76xScaMw0MrA=="
       },
       "Ardalis.GuardClauses": {
         "type": "Transitive",

--- a/src/InformaticsGateway/Services/HealthLevel7/MllpService.cs
+++ b/src/InformaticsGateway/Services/HealthLevel7/MllpService.cs
@@ -220,7 +220,7 @@ namespace Monai.Deploy.InformaticsGateway.Api.Mllp
                 {
                     try
                     {
-                        pluginAssemblies.AddRange(config.PlugInAssemblies.Where(p => pluginAssemblies.Contains(p) is false));
+                        pluginAssemblies.AddRange(config.PlugInAssemblies.Where(p => string.IsNullOrWhiteSpace(p) is false && pluginAssemblies.Contains(p) is false));
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
### Description

Fixes # .

An issue where if the HL7Config had an empty string for the plugin name, it failed to process the Hl7Messages

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] I have updated the changelog
