### PR TITLE
Composite Key (WorkflowInstanceId + ExportTaskId) for Export Deduplication

### DIFF
--- a/src/InformaticsGateway/Services/Export/ExportServiceBase.cs
+++ b/src/InformaticsGateway/Services/Export/ExportServiceBase.cs
@@ -53,6 +53,8 @@ namespace Monai.Deploy.InformaticsGateway.Services.Export
     {
         protected static readonly object SyncRoot = new();
 
+        protected static string BuildExportKey(string workflowInstanceId, string exportTaskId) => $"{workflowInstanceId}/{exportTaskId}";
+
         internal event EventHandler? ReportActionCompleted;
 
         private readonly CancellationTokenSource _cancellationTokenSource;
@@ -373,7 +375,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Export
 
         private void ReportingActionBlock(ExportRequestDataMessage exportRequestData)
         {
-            var exportRequest = ExportRequests[exportRequestData.ExportTaskId];
+            var exportRequest = ExportRequests[BuildExportKey(exportRequestData.WorkflowInstanceId, exportRequestData.ExportTaskId)];
             HandleStatus(exportRequestData, exportRequest);
             if (!exportRequest.IsCompleted)
             {
@@ -391,7 +393,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Export
 
             lock (SyncRoot)
             {
-                ExportRequests.Remove(exportRequestData.ExportTaskId);
+                ExportRequests.Remove(BuildExportKey(exportRequestData.WorkflowInstanceId, exportRequestData.ExportTaskId));
             }
 
             if (ReportActionCompleted != null)
@@ -588,7 +590,8 @@ namespace Monai.Deploy.InformaticsGateway.Services.Export
             lock (SyncRoot)
             {
                 var exportRequest = eventArgs.Message.ConvertTo<ExportRequestEvent>();
-                if (ExportRequests.ContainsKey(exportRequest.ExportTaskId))
+                string exportKey = BuildExportKey(exportRequest.WorkflowInstanceId, exportRequest.ExportTaskId);
+                if (ExportRequests.ContainsKey(exportKey))
                 {
                     _logger.ExportRequestAlreadyQueued(exportRequest.CorrelationId, exportRequest.ExportTaskId);
                     return;
@@ -599,7 +602,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Export
 
                 var exportRequestWithDetails = new ExportRequestEventDetails(exportRequest);
 
-                ExportRequests.Add(exportRequest.ExportTaskId, exportRequestWithDetails);
+                ExportRequests.Add(exportKey, exportRequestWithDetails);
                 if (!exportFlow.Post(exportRequestWithDetails))
                 {
                     _logger.ErrorPostingExportJobToQueue(exportRequest.CorrelationId, exportRequest.ExportTaskId);

--- a/src/InformaticsGateway/Services/Export/ExtAppScuExportService.cs
+++ b/src/InformaticsGateway/Services/Export/ExtAppScuExportService.cs
@@ -67,7 +67,8 @@ namespace Monai.Deploy.InformaticsGateway.Services.Export
             lock (SyncRoot)
             {
                 var externalAppRequest = eventArgs.Message.ConvertTo<ExternalAppRequestEvent>();
-                if (ExportRequests.ContainsKey(externalAppRequest.ExportTaskId))
+                string exportKey = BuildExportKey(externalAppRequest.WorkflowInstanceId, externalAppRequest.ExportTaskId);
+                if (ExportRequests.ContainsKey(exportKey))
                 {
                     _logger.ExportRequestAlreadyQueued(externalAppRequest.CorrelationId, externalAppRequest.ExportTaskId);
                     return;
@@ -78,7 +79,7 @@ namespace Monai.Deploy.InformaticsGateway.Services.Export
 
                 var exportRequestWithDetails = new ExportRequestEventDetails(externalAppRequest);
 
-                ExportRequests.Add(externalAppRequest.ExportTaskId, exportRequestWithDetails);
+                ExportRequests.Add(exportKey, exportRequestWithDetails);
                 if (!exportFlow.Post(exportRequestWithDetails))
                 {
                     _logger.ErrorPostingExportJobToQueue(externalAppRequest.CorrelationId, externalAppRequest.ExportTaskId);

--- a/src/InformaticsGateway/Test/Services/Export/ExportServiceBaseTest.cs
+++ b/src/InformaticsGateway/Test/Services/Export/ExportServiceBaseTest.cs
@@ -81,7 +81,8 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Export
             lock (SyncRoot)
             {
                 var exportRequest = eventArgs.Message.ConvertTo<ExportRequestEvent>();
-                if (ExportRequests.ContainsKey(exportRequest.ExportTaskId))
+                string exportKey = BuildExportKey(exportRequest.WorkflowInstanceId, exportRequest.ExportTaskId);
+                if (ExportRequests.ContainsKey(exportKey))
                 {
                     return;
                 }
@@ -91,7 +92,7 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Export
 
                 var exportRequestWithDetails = new ExportRequestEventDetails(exportRequest);
 
-                ExportRequests.Add(exportRequest.ExportTaskId, exportRequestWithDetails);
+                ExportRequests.Add(exportKey, exportRequestWithDetails);
                 if (!exportFlow.Post(exportRequestWithDetails))
                 {
                     MessageSubscriber.Reject(eventArgs.Message);
@@ -340,6 +341,62 @@ namespace Monai.Deploy.InformaticsGateway.Test.Services.Export
                                                               It.IsAny<ushort>()), Times.Once());
             _outputDataPlugInEngine.Verify(p => p.Configure(It.IsAny<IReadOnlyList<string>>()), Times.Exactly(5 * 2));
             _outputDataPlugInEngine.Verify(p => p.ExecutePlugInsAsync(It.IsAny<ExportRequestDataMessage>()), Times.Exactly(5 * 2));
+        }
+
+        [RetryFact(1, 10, DisplayName = "Data flow test - same ExportTaskId different WorkflowInstanceId are not deduplicated")]
+        public async Task DataflowTest_SameExportTaskId_DifferentWorkflowInstanceId_BothProcessed()
+        {
+            var sharedExportTaskId = Guid.NewGuid().ToString();
+            var completedCount = 0;
+
+            _messagePublisherService.Setup(p => p.Publish(It.IsAny<string>(), It.IsAny<Message>()));
+            _messageSubscriberService.Setup(p => p.Acknowledge(It.IsAny<MessageBase>()));
+            _messageSubscriberService.Setup(p => p.RequeueWithDelay(It.IsAny<MessageBase>()));
+            _messageSubscriberService.Setup(
+                p => p.SubscribeAsync(It.IsAny<string>(),
+                                 It.IsAny<string>(),
+                                 It.IsAny<Func<MessageReceivedEventArgs, Task>>(),
+                                 It.IsAny<ushort>()))
+                .Callback<string, string, Func<MessageReceivedEventArgs, Task>, ushort>(async (topic, queue, messageReceivedCallback, prefetchCount) =>
+                {
+                    // Same ExportTaskId, two different WorkflowInstanceIds - must NOT be deduplicated
+                    await messageReceivedCallback(CreateMessageReceivedEventArgs(Guid.NewGuid().ToString(), sharedExportTaskId));
+                    await messageReceivedCallback(CreateMessageReceivedEventArgs(Guid.NewGuid().ToString(), sharedExportTaskId));
+                });
+
+            _storageService.Setup(p => p.GetObjectAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes("test")));
+
+            var countdownEvent = new CountdownEvent(2);
+            var service = new TestExportService(_logger.Object, _configuration, _serviceScopeFactory.Object, _dicomToolkit.Object);
+            service.ReportActionCompleted += (sender, e) =>
+            {
+                Interlocked.Increment(ref completedCount);
+                countdownEvent.Signal();
+            };
+            await service.StartAsync(_cancellationTokenSource.Token);
+            Assert.True(countdownEvent.Wait(60000), $"Expected 2 exports to complete but only {completedCount} completed - second request was incorrectly deduplicated");
+            await StopAndVerify(service);
+
+            _messagePublisherService.Verify(
+                p => p.Publish(It.IsAny<string>(),
+                               It.Is<Message>(match => (match.ConvertTo<ExportCompleteEvent>()).Status == ExportStatus.Success)), Times.Exactly(2));
+            _messageSubscriberService.Verify(p => p.Acknowledge(It.IsAny<MessageBase>()), Times.Exactly(2));
+        }
+
+        internal static MessageReceivedEventArgs CreateMessageReceivedEventArgs(string workflowInstanceId, string exportTaskId)
+        {
+            var exportRequestEvent = new ExportRequestEvent
+            {
+                ExportTaskId = exportTaskId,
+                CorrelationId = Guid.NewGuid().ToString(),
+                Destinations = new[] { "destination" },
+                Files = new[] { "file1", "file2" },
+                MessageId = Guid.NewGuid().ToString(),
+                WorkflowInstanceId = workflowInstanceId,
+            };
+            var jsonMessage = new JsonMessage<ExportRequestEvent>(exportRequestEvent, MessageBrokerConfiguration.InformaticsGatewayApplicationId, exportRequestEvent.CorrelationId, exportRequestEvent.DeliveryTag);
+            return new MessageReceivedEventArgs(jsonMessage.ToMessage(), CancellationToken.None);
         }
 
         internal static MessageReceivedEventArgs CreateMessageReceivedEventArgs()


### PR DESCRIPTION
### Description

Previously, `ExportServiceBase` used only `ExportTaskId` as the key for tracking in-progress export requests. This caused requests with the same `ExportTaskId` but different `WorkflowInstanceIds` to be incorrectly deduplicated, silently dropping valid export tasks. This eventually leads to RabbitMQ timeout, Informatics Gateway -- RabbitMQ disconnection, and blocking of the Informatics Gateway due to failure to resolve the dropped valid export tasks.

This issue commonly happens when two workflow instances are executing at the same time, and the Task Ids associated with each workflow are identically named (for example, `"id": "export-svrtk-orthanc"` for a task that exports SVRTK series to ORTHANC).

Manifestation in MONAI Deploy Express environment:

`mdl-ig` logs:

```bash
# first workflow export task
2026-02-20 14:09:38.1761|532|INFO|Monai.Deploy.InformaticsGateway.Services.Export.ScuExportService||CorrelationId=b8d68125-09e3-4731-b859-b97dca0c998f. MessageId=export-svrtk-orthanc. Export request 703ac500-2c41-47ee-8d89-a545dd9f5a70 received & queued for processing.

# second workflow export task - collision
2026-02-20 14:09:41.0543|502|WARN|Monai.Deploy.InformaticsGateway.Services.Export.ScuExportService||CorrelationId=b8d68125-09e3-4731-b859-b97dca0c998f. The export request export-svrtk-orthanc is already queued for export. 

# RabbitMQ timeout
2026-02-20 14:40:31.7626|10013|ERROR|Monai.Deploy.Messaging.RabbitMQ.RabbitMQConnectionFactory||RabbitMQ connection shutdown: AMQP close-reason, initiated by Peer, code=406, text='PRECONDITION_FAILED - delivery acknowledgement on channel 1 timed out. Timeout value used: 1800000 ms. This timeout value can be configured, see consumers doc guide to learn more', classId=0, methodId=0. 

# after RabbitMQ timeout, task gets re-queued
2026-02-20 14:42:07.4279|532|INFO|Monai.Deploy.InformaticsGateway.Services.Export.ScuExportService||CorrelationId=b8d68125-09e3-4731-b859-b97dca0c998f. MessageId=export-svrtk-orthanc. Export request 7614502a-1988-4f0f-9c3a-9a15d85d0a12 received & queued for processing.
```

Rabbit MQ UI (Timeout Period):

<img width="1045" height="772" alt="image" src="https://github.com/user-attachments/assets/8bf010fc-bd53-43ca-a358-5117a9d8a20c" />

RabbitMQ UI (IG Blocked):

<img width="1729" height="774" alt="image" src="https://github.com/user-attachments/assets/c1c2c992-56e8-4d76-b2da-5f9fda019405" />

Changes:
- Add `BuildExportKey()` helper combining `WorkflowInstanceId` and `ExportTaskId` as a composite key
- Apply composite key in `ReportingActionBlock` lookups and in `ExtAppScuExportService.ExportRequests` dictionary
- Add regression test: `DataflowTest_SameExportTaskId_DifferentWorkflowInstanceId_BothProcessed` verifying both tasks are processed"

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] I have updated the changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where exports with the same task ID from different workflow instances could be incorrectly handled. The system now properly processes each export independently.

* **Tests**
  * Added test coverage verifying that exports with identical task IDs from different workflow instances are both processed successfully without unintended interference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->